### PR TITLE
Changed import config (hearthstoneplayers)

### DIFF
--- a/Hearthstone Deck Tracker/DeckImporter.cs
+++ b/Hearthstone Deck Tracker/DeckImporter.cs
@@ -332,7 +332,7 @@ namespace Hearthstone_Deck_Tracker
 				var deckName = HttpUtility.HtmlDecode(doc.DocumentNode.SelectSingleNode("//*[@id='deck-list-title']").InnerText);
 				deck.Name = deckName;
 
-				var cardNodes = doc.DocumentNode.SelectNodes("//div[contains(@class,'deck-list')]/div/div[contains(@class,'card')]");
+				var cardNodes = doc.DocumentNode.SelectNodes("//div[contains(@class,'guide-deck-list')]/div/div[contains(@class,'card')]");
 				foreach(var cardNode in cardNodes)
 				{
 					//silly names contain right-single quotation mark


### PR DESCRIPTION
Multiple `<div class="deck-list">` can be on the same page. However, it seems that
the div element containing the deck list is also `class="guide-deck-list"`. This
class seems to be unique within the document.

Fix switches deck-list to guide-deck-list.