### PR TITLE
Added the ability to save to an own data directoy

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -67,7 +67,10 @@ namespace Hearthstone_Deck_Tracker
 		[DefaultValue(-1)]
 		public int CustomWidth = -1;
 
-		[DefaultValue(false)]
+        [DefaultValue("")]
+        public string DataDirPath = string.Empty;
+
+        [DefaultValue(false)]
 		[XmlIgnore]
 		public bool Debug = false;
 
@@ -574,7 +577,7 @@ namespace Hearthstone_Deck_Tracker
 
 		public string DataDir
 		{
-			get { return Instance.SaveDataInAppData == false ? string.Empty : AppDataPath + "\\"; }
+			get { return Instance.SaveDataInAppData == false ? DataDirPath + "\\" : AppDataPath + "\\"; }
 		}
 
 		public string ReplayDir

--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -67,8 +67,8 @@ namespace Hearthstone_Deck_Tracker
 		[DefaultValue(-1)]
 		public int CustomWidth = -1;
 
-        [DefaultValue("")]
-        public string DataDirPath = string.Empty;
+        [DefaultValue(".")]
+        public string DataDirPath = ".";
 
         [DefaultValue(false)]
 		[XmlIgnore]

--- a/Hearthstone Deck Tracker/FlyoutControls/Options.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options.xaml
@@ -459,6 +459,7 @@
                                               Unchecked="CheckboxLogTab_Unchecked" />
                                     <Button Name="ButtonGamePath" Margin="10,5,10,0" Content ="set hearthstone path" Click="ButtonGamePath_OnClick"/>
                                     <Button Name="ButtonOpenAppData" Margin="10,5,10,0" Content ="open appdata folder" Click="ButtonOpenAppData_OnClick"/>
+                                    <Button Name="SelectSaveDataPath" Margin="10,5,10,0" Content="set data path" Click="SelectSaveDataPath_Click"/>
                                 </StackPanel>
                             </GroupBox>
                         </Grid>

--- a/Hearthstone Deck Tracker/FlyoutControls/Options.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options.xaml.cs
@@ -1297,7 +1297,21 @@ namespace Hearthstone_Deck_Tracker
 			}
 		}
 
-		private void CheckboxDeleteDeckKeepStats_Checked(object sender, RoutedEventArgs e)
+        private async void SelectSaveDataPath_Click(object sender, RoutedEventArgs e)
+        {
+            System.Windows.Forms.FolderBrowserDialog dialog = new System.Windows.Forms.FolderBrowserDialog();
+            System.Windows.Forms.DialogResult dialogResult = dialog.ShowDialog();
+
+            if (dialogResult == System.Windows.Forms.DialogResult.OK)
+            {
+                Config.Instance.DataDirPath = dialog.SelectedPath;
+                Config.Save();
+                await Helper.MainWindow.Restart();
+            }
+
+        }
+
+        private void CheckboxDeleteDeckKeepStats_Checked(object sender, RoutedEventArgs e)
 		{
 			if(!_initialized)
 				return;
@@ -1483,6 +1497,6 @@ namespace Hearthstone_Deck_Tracker
             Config.Instance.SaveHSLogIntoReplay = false;
             SaveConfig(false);
         }
-	}
+    }
 }
  

--- a/Hearthstone Deck Tracker/FlyoutControls/Options.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options.xaml.cs
@@ -15,6 +15,7 @@ using Microsoft.Win32;
 using Brush = System.Windows.Media.Brush;
 using Color = System.Windows.Media.Color;
 using SystemColors = System.Windows.SystemColors;
+using System.Collections.Generic;
 
 namespace Hearthstone_Deck_Tracker
 {
@@ -1304,6 +1305,17 @@ namespace Hearthstone_Deck_Tracker
 
             if (dialogResult == System.Windows.Forms.DialogResult.OK)
             {
+                if (Config.Instance.SaveDataInAppData != null && !Config.Instance.SaveDataInAppData.Value)
+                {
+                    foreach(bool value in new List<bool> { true, false}) {
+                        Config.Instance.SaveDataInAppData = value;
+                        Helper.MainWindow.CopyReplayFiles();
+                        Helper.MainWindow.SetupDeckStatsFile();
+                        Helper.MainWindow.SetupDeckListFile();
+                        Helper.MainWindow.SetupDefaultDeckStatsFile();
+                        Config.Instance.DataDirPath = dialog.SelectedPath;
+                    }
+                }
                 Config.Instance.DataDirPath = dialog.SelectedPath;
                 Config.Save();
                 await Helper.MainWindow.Restart();

--- a/Hearthstone Deck Tracker/FlyoutControls/Options.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options.xaml.cs
@@ -1190,10 +1190,10 @@ namespace Hearthstone_Deck_Tracker
 			await Helper.MainWindow.Restart();
 		}
 
-		private async void CheckboxDataSaveAppData_Checked(object sender, RoutedEventArgs e)
+        private async void CheckboxDataSaveAppData_Checked(object sender, RoutedEventArgs e)
 		{
 			if(!_initialized) return;
-			Config.Instance.SaveDataInAppData = true;
+            Config.Instance.SaveDataInAppData = true;
 			Config.Save();
 			await Helper.MainWindow.Restart();
 		}
@@ -1201,7 +1201,7 @@ namespace Hearthstone_Deck_Tracker
 		private async void CheckboxDataSaveAppData_Unchecked(object sender, RoutedEventArgs e)
 		{
 			if(!_initialized) return;
-			Config.Instance.SaveDataInAppData = false;
+            Config.Instance.SaveDataInAppData = false;
 			Config.Save();
 			await Helper.MainWindow.Restart();
 		}

--- a/Hearthstone Deck Tracker/MainWindow/MainWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow.xaml.cs
@@ -284,6 +284,8 @@ namespace Hearthstone_Deck_Tracker
 
 			Helper.SortCardCollection(ListViewDeck.Items, Config.Instance.CardSortingClassFirst);
 			DeckPickerList.SortDecks();
+
+            CopyReplayFiles();
 		}
 
 		#endregion

--- a/Hearthstone Deck Tracker/MainWindow/MainWindow_Load.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow_Load.cs
@@ -66,17 +66,62 @@ namespace Hearthstone_Deck_Tracker
 			OpponentWindow.UpdateOpponentLayout();
 		}
 
+        private void CopyReplayFiles()
+        {
+            if (Config.Instance.SaveDataInAppData == null)
+                return;
+            var appDataReplayDirPath = Config.Instance.AppDataPath + @"\Replays";
+            string dataReplayDirPath = Config.Instance.DataDirPath + @"\Replays";
+            if (Config.Instance.SaveDataInAppData.Value)
+            {
+                if (Directory.Exists(dataReplayDirPath))
+                {
+                    //backup in case the file already exists
+                    var time = DateTime.Now.ToFileTime();
+                    if (Directory.Exists(appDataReplayDirPath))
+                    {
+                        Helper.CopyFolder(appDataReplayDirPath, appDataReplayDirPath + time);
+                        Directory.Delete(appDataReplayDirPath, true);
+                        Logger.WriteLine("Created backups of replays in appdata");
+                    }
+
+
+                    Helper.CopyFolder(dataReplayDirPath, appDataReplayDirPath);
+                    Directory.Delete(dataReplayDirPath, true);
+
+                    Logger.WriteLine("Moved Games to appdata");
+                }
+
+            }
+            else if (Directory.Exists(appDataReplayDirPath))    //Save in DataDir and AppData Replay dir still exists
+            {
+                //backup in case the file already exists
+                var time = DateTime.Now.ToFileTime();
+                if (Directory.Exists(dataReplayDirPath))
+                {
+                    Helper.CopyFolder(dataReplayDirPath, dataReplayDirPath + time);
+                    Directory.Delete(dataReplayDirPath, true);
+                }
+                Logger.WriteLine("Created backups of replays locally");
+
+
+                Helper.CopyFolder(appDataReplayDirPath, dataReplayDirPath);
+                Directory.Delete(appDataReplayDirPath, true);
+                Logger.WriteLine("Moved Games to appdata");
+            }
+        }
+
 		private void SetupDeckStatsFile()
 		{
 			if(Config.Instance.SaveDataInAppData == null)
 				return;
             var appDataPath = Config.Instance.AppDataPath + @"\DeckStats.xml";
 			var appDataGamesDirPath = Config.Instance.AppDataPath + @"\Games";
-			const string localPath = "DeckStats.xml";
-			const string localGamesDirPath = "Games";
+			string dataDirPath = Config.Instance.DataDirPath +  @"\DeckStats.xml";
+			string dataGamesDirPath = Config.Instance.DataDirPath + @"\Games";
 			if(Config.Instance.SaveDataInAppData.Value)
 			{
-				if(File.Exists(localPath))
+				if(File.Exists(dataDirPath))
 				{
 					if(File.Exists(appDataPath))
 					{
@@ -90,35 +135,35 @@ namespace Hearthstone_Deck_Tracker
 						}
 						Logger.WriteLine("Created backups of deckstats and games in appdata");
 					}
-					File.Move(localPath, appDataPath);
+					File.Move(dataDirPath, appDataPath);
 					Logger.WriteLine("Moved DeckStats to appdata");
-					if(Directory.Exists(localGamesDirPath))
+					if(Directory.Exists(dataGamesDirPath))
 					{
-						Helper.CopyFolder(localGamesDirPath, appDataGamesDirPath);
-						Directory.Delete(localGamesDirPath, true);
+						Helper.CopyFolder(dataGamesDirPath, appDataGamesDirPath);
+						Directory.Delete(dataGamesDirPath, true);
 					}
 					Logger.WriteLine("Moved Games to appdata");
 				}
 			}
 			else if(File.Exists(appDataPath))
 			{
-				if(File.Exists(localPath))
+				if(File.Exists(dataDirPath))
 				{
 					//backup in case the file already exists
 					var time = DateTime.Now.ToFileTime();
-					File.Move(localPath, localPath + time);
-					if(Directory.Exists(localGamesDirPath))
+					File.Move(dataDirPath, dataDirPath + time);
+					if(Directory.Exists(dataGamesDirPath))
 					{
-						Helper.CopyFolder(localGamesDirPath, localGamesDirPath + time);
-						Directory.Delete(localGamesDirPath, true);
+						Helper.CopyFolder(dataGamesDirPath, dataGamesDirPath + time);
+						Directory.Delete(dataGamesDirPath, true);
 					}
 					Logger.WriteLine("Created backups of deckstats and games locally");
 				}
-				File.Move(appDataPath, localPath);
+				File.Move(appDataPath, dataDirPath);
 				Logger.WriteLine("Moved DeckStats to local");
 				if(Directory.Exists(appDataGamesDirPath))
 				{
-					Helper.CopyFolder(appDataGamesDirPath, localGamesDirPath);
+					Helper.CopyFolder(appDataGamesDirPath, dataGamesDirPath);
 					Directory.Delete(appDataGamesDirPath, true);
 				}
 				Logger.WriteLine("Moved Games to appdata");
@@ -332,24 +377,24 @@ namespace Hearthstone_Deck_Tracker
 			if(Config.Instance.SaveDataInAppData == null)
 				return;
 			var appDataPath = Config.Instance.AppDataPath + @"\PlayerDecks.xml";
-			const string localPath = "PlayerDecks.xml";
+			string dataDirPath = Config.Instance.DataDirPath + @"\PlayerDecks.xml";
 			if(Config.Instance.SaveDataInAppData.Value)
 			{
-				if(File.Exists(localPath))
+				if(File.Exists(dataDirPath))
 				{
 					if(File.Exists(appDataPath))
 						//backup in case the file already exists
 						File.Move(appDataPath, appDataPath + DateTime.Now.ToFileTime());
-					File.Move(localPath, appDataPath);
+					File.Move(dataDirPath, appDataPath);
 					Logger.WriteLine("Moved decks to appdata");
 				}
 			}
 			else if(File.Exists(appDataPath))
 			{
-				if(File.Exists(localPath))
+				if(File.Exists(dataDirPath))
 					//backup in case the file already exists
-					File.Move(localPath, localPath + DateTime.Now.ToFileTime());
-				File.Move(appDataPath, localPath);
+					File.Move(dataDirPath, dataDirPath + DateTime.Now.ToFileTime());
+				File.Move(appDataPath, dataDirPath);
 				Logger.WriteLine("Moved decks to local");
 			}
 
@@ -370,10 +415,10 @@ namespace Hearthstone_Deck_Tracker
 			if(Config.Instance.SaveDataInAppData == null)
 				return;
 			var appDataPath = Config.Instance.AppDataPath + @"\DefaultDeckStats.xml";
-			const string localPath = "DefaultDeckStats.xml";
+			string dataDirPath = Config.Instance.DataDirPath + @"\DefaultDeckStats.xml";
 			if(Config.Instance.SaveDataInAppData.Value)
 			{
-				if(File.Exists(localPath))
+				if(File.Exists(dataDirPath))
 				{
 					if(File.Exists(appDataPath))
 					{
@@ -382,20 +427,20 @@ namespace Hearthstone_Deck_Tracker
 						File.Move(appDataPath, appDataPath + time);
 						Logger.WriteLine("Created backups of DefaultDeckStats in appdata");
 					}
-					File.Move(localPath, appDataPath);
+					File.Move(dataDirPath, appDataPath);
 					Logger.WriteLine("Moved DefaultDeckStats to appdata");
 				}
 			}
 			else if(File.Exists(appDataPath))
 			{
-				if(File.Exists(localPath))
+				if(File.Exists(dataDirPath))
 				{
 					//backup in case the file already exists
 					var time = DateTime.Now.ToFileTime();
-					File.Move(localPath, localPath + time);
+					File.Move(dataDirPath, dataDirPath + time);
 					Logger.WriteLine("Created backups of DefaultDeckStats locally");
 				}
-				File.Move(appDataPath, localPath);
+				File.Move(appDataPath, dataDirPath);
 				Logger.WriteLine("Moved DefaultDeckStats to local");
 			}
 

--- a/Hearthstone Deck Tracker/MainWindow/MainWindow_Load.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow_Load.cs
@@ -66,7 +66,7 @@ namespace Hearthstone_Deck_Tracker
 			OpponentWindow.UpdateOpponentLayout();
 		}
 
-        private void CopyReplayFiles()
+        public void CopyReplayFiles()
         {
             if (Config.Instance.SaveDataInAppData == null)
                 return;
@@ -111,7 +111,7 @@ namespace Hearthstone_Deck_Tracker
             }
         }
 
-		private void SetupDeckStatsFile()
+		public void SetupDeckStatsFile()
 		{
 			if(Config.Instance.SaveDataInAppData == null)
 				return;
@@ -372,7 +372,7 @@ namespace Hearthstone_Deck_Tracker
 			return updated;
 		}
 
-		private void SetupDeckListFile()
+		public void SetupDeckListFile()
 		{
 			if(Config.Instance.SaveDataInAppData == null)
 				return;
@@ -410,7 +410,7 @@ namespace Hearthstone_Deck_Tracker
 				File.Copy(_decksPath, _decksPath + ".old");
 		}
 
-		private void SetupDefaultDeckStatsFile()
+		public void SetupDefaultDeckStatsFile()
 		{
 			if(Config.Instance.SaveDataInAppData == null)
 				return;


### PR DESCRIPTION
With every new release, I was constantly updating the Config.Instance.DataDir variable to point to my cloud storage, such that I had access to all current decks from different devices. 

I finally decided to to add the ability into the options menu, such that the folder can be set and saved in the config file. It can be found in options > Other > Tracker at the very bottom