### PR TITLE
Missing Cards Ingame

### DIFF
--- a/Hearthstone Deck Tracker/MainWindow/MainWindow_Export.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow_Export.cs
@@ -50,10 +50,64 @@ namespace Hearthstone_Deck_Tracker
 				await controller.CloseAsync();
 
 				if(deck.MissingCards.Any())
-					this.ShowMissingCardsMessage(deck);
+				{
+					string missingcards = MissingCardsMessage(deck);
+					var hsRect = User32.GetHearthstoneRect(false);
+					if(((float)hsRect.Width / (float)hsRect.Height) > 1.5)
+						Helper.MainWindow.Overlay.ShowMissingCards(missingcards);
+					else
+						this.ShowMissingCardsMessage(missingcards);
+				}
 			}
 		}
 
+		public string MissingCardsMessage (Deck deck)
+		{
+			if(!deck.MissingCards.Any())
+			{
+				return (string)"";
+			}
+			var message = "The following cards were \nnot found:\n";
+			var totalDust = 0;
+			var promo = "";
+			var nax = "";
+			foreach(var card in deck.MissingCards)
+			{
+				message += "\n• " + card.LocalizedName;
+
+				int dust;
+				switch(card.Rarity)
+				{
+					case "Common":
+						dust = 40;
+						break;
+					case "Rare":
+						dust = 100;
+						break;
+					case "Epic":
+						dust = 400;
+						break;
+					case "Legendary":
+						dust = 1600;
+						break;
+					default:
+						dust = 0;
+						break;
+				}
+
+				if(card.Count == 2)
+					message += " x2";
+
+				if(card.Set.Equals("CURSE OF NAXXRAMAS", System.StringComparison.CurrentCultureIgnoreCase))
+					nax = "\nand the Naxxramas DLC ";
+				else if(card.Set.Equals("PROMOTION", System.StringComparison.CurrentCultureIgnoreCase))
+					promo = "\nand Promotion cards ";
+				else
+					totalDust += dust * card.Count;
+			}
+			message += string.Format("\n\nYou need {0} dust {1}{2}\nto craft the missing cards.", totalDust, nax, promo);
+			return message;
+		}
 
 		private async void BtnScreenhot_Click(object sender, RoutedEventArgs e)
 		{
@@ -130,7 +184,8 @@ namespace Hearthstone_Deck_Tracker
 			var deck = DeckPickerList.GetSelectedDeckVersion();
 			if(deck == null)
 				return;
-			this.ShowMissingCardsMessage(deck);
+			string missingcards = MissingCardsMessage(deck);
+			this.ShowMissingCardsMessage(missingcards);
 		}
 	}
 }

--- a/Hearthstone Deck Tracker/Windows/MessageDialogs.cs
+++ b/Hearthstone Deck Tracker/Windows/MessageDialogs.cs
@@ -78,55 +78,17 @@ namespace Hearthstone_Deck_Tracker.Windows
 			}
 		}
 
-		public static async void ShowMissingCardsMessage(this MetroWindow window, Deck deck)
+		public static async void ShowMissingCardsMessage(this MetroWindow window, string message)
 		{
-			if(!deck.MissingCards.Any())
+			if (message.Equals(""))
 			{
 				await
-					window.ShowMessageAsync("No missing cards",
-					                        "No cards were missing when you last exported this deck. (or you have not recently exported this deck)",
-					                        MessageDialogStyle.Affirmative, new MetroDialogSettings {AffirmativeButtonText = "OK"});
+				window.ShowMessageAsync("No missing cards",
+										"No cards were missing when you last exported this deck. (or you have not recently exported this deck)",
+										MessageDialogStyle.Affirmative, new MetroDialogSettings { AffirmativeButtonText = "OK" });
 				return;
 			}
-			var message = "The following cards were not found:\n";
-			var totalDust = 0;
-			var promo = "";
-			var nax = "";
-			foreach(var card in deck.MissingCards)
-			{
-				message += "\n• " + card.LocalizedName;
 
-				int dust;
-				switch(card.Rarity)
-				{
-					case "Common":
-						dust = 40;
-						break;
-					case "Rare":
-						dust = 100;
-						break;
-					case "Epic":
-						dust = 400;
-						break;
-					case "Legendary":
-						dust = 1600;
-						break;
-					default:
-						dust = 0;
-						break;
-				}
-
-				if(card.Count == 2)
-					message += " x2";
-
-				if(card.Set.Equals("CURSE OF NAXXRAMAS", StringComparison.CurrentCultureIgnoreCase))
-					nax = "and the Naxxramas DLC ";
-				else if(card.Set.Equals("PROMOTION", StringComparison.CurrentCultureIgnoreCase))
-					promo = "and Promotion cards ";
-				else
-					totalDust += dust * card.Count;
-			}
-			message += string.Format("\n\nYou need {0} dust {1}{2}to craft the missing cards.", totalDust, nax, promo);
 			await
 				window.ShowMessageAsync("Export incomplete", message, MessageDialogStyle.Affirmative,
 				                        new MetroDialogSettings {AffirmativeButtonText = "OK"});

--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml
@@ -1,133 +1,140 @@
-﻿<Window x:Class="Hearthstone_Deck_Tracker.OverlayWindow"
+﻿<Window
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Hearthstone_Deck_Tracker"
+        xmlns:Controls="clr-namespace:Hearthstone_Deck_Tracker.Replay.Controls" x:Class="Hearthstone_Deck_Tracker.OverlayWindow"
         Title="HearthstoneOverlay" Height="571" Width="832" Background="{x:Null}" ResizeMode="NoResize"
         ShowInTaskbar="False" SourceInitialized="Window_SourceInitialized_1" AllowsTransparency="True"
         WindowStyle="None" Topmost="True" Closing="Window_Closing">
     <Grid>
 
-        <Canvas Name="CanvasInfo" HorizontalAlignment="Left" Height="571" VerticalAlignment="Top" Width="832">
+        <Canvas x:Name="CanvasInfo" HorizontalAlignment="Left" Height="571" VerticalAlignment="Top" Width="832">
             <local:HearthstoneTextBlock Visibility="Hidden" x:Name="LblOpponentTurnTime" Text="0" Canvas.Top="418"
-                                        Canvas.Left="418" FontSize="24" />
+				Canvas.Left="418" FontSize="24" />
             <local:HearthstoneTextBlock Visibility="Hidden" x:Name="LblTurnTime" Text="90" Canvas.Top="378"
-                                        Canvas.Left="353" FontSize="32" />
+				Canvas.Left="353" FontSize="32" />
             <local:HearthstoneTextBlock Visibility="Hidden" x:Name="LblPlayerTurnTime" Text="0" Canvas.Top="338"
-                                        Canvas.Left="418" FontSize="24" />
+				Canvas.Left="418" FontSize="24" />
+
 
             <ScrollViewer x:Name="DebugViewer" Height="100" Width="400" Canvas.Left="200" Visibility="Hidden"
-                          Background="Beige" Foreground="Aqua" Opacity="75"
-                          VerticalScrollBarVisibility="Visible">
+				Background="Beige" Foreground="Aqua" Opacity="75"
+				VerticalScrollBarVisibility="Visible">
                 <TextBox x:Name="LblDebugLog" Text="Test" TextWrapping="Wrap" FontSize="14" Foreground="Aqua" />
             </ScrollViewer>
 
-            <StackPanel Name="StackPanelPlayer" Canvas.Left="438" Canvas.Top="47" Width="218">
+            <StackPanel x:Name="StackPanelPlayer" Canvas.Left="438" Canvas.Top="47" Width="218">
                 <local:HearthstoneTextBlock x:Name="LblDeckTitle" FontSize="16" Text="Deck title" />
                 <local:HearthstoneTextBlock x:Name="LblWins" FontSize="16" Text="0 - 0 (0%)" />
                 <local:DeckListView x:Name="ListViewPlayer" Height="auto" Canvas.Left="350" Canvas.Top="147"
-                                    Width="218" Background="{x:Null}" Foreground="White" FontWeight="Bold"
-                                    BorderThickness="0" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                                    ScrollViewer.VerticalScrollBarVisibility="Disabled"
-                                    ScrollViewer.CanContentScroll="False" FontFamily="Arial">
-                    <ListView.Resources>
-                        <Style TargetType="GridViewColumnHeader">
+					Width="218" Background="{x:Null}" Foreground="White" FontWeight="Bold"
+					BorderThickness="0" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+					ScrollViewer.VerticalScrollBarVisibility="Disabled"
+					ScrollViewer.CanContentScroll="False" FontFamily="Arial">
+                    <local:DeckListView.Resources>
+                        <Style TargetType="{x:Type GridViewColumnHeader}">
                             <Setter Property="Visibility" Value="Collapsed" />
                         </Style>
-                        <Style TargetType="ListViewItem">
+                        <Style TargetType="{x:Type ListViewItem}">
                             <Setter Property="Foreground" Value="{Binding ColorPlayer}" />
                             <Setter Property="Background" Value="{Binding Background}" />
                             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                             <Setter Property="Height" Value="{Binding Height}" />
                             <Setter Property="Margin" Value="0,-2,0,0" />
                         </Style>
-                    </ListView.Resources>
+                    </local:DeckListView.Resources>
                 </local:DeckListView>
-                <StackPanel Name="StackPanelPlayerDraw" Orientation="Horizontal" HorizontalAlignment="Center">
+                <StackPanel x:Name="StackPanelPlayerDraw" Orientation="Horizontal" HorizontalAlignment="Center">
                     <local:HearthstoneTextBlock x:Name="LblDrawChance2" FontSize="16" Text="0%" />
                     <local:HearthstoneTextBlock x:Name="LblDrawChance1" FontSize="16" Text="0%" Margin="4,0,0,0" />
                 </StackPanel>
-                <StackPanel Name="StackPanelPlayerCount" Orientation="Horizontal" HorizontalAlignment="Center">
+                <StackPanel x:Name="StackPanelPlayerCount" Orientation="Horizontal" HorizontalAlignment="Center">
                     <local:HearthstoneTextBlock x:Name="LblCardCount" FontSize="14" Text="Hand: 0" />
                     <local:HearthstoneTextBlock x:Name="LblDeckCount" FontSize="14" Text="Deck: 0" Margin="4,0,0,0" />
                 </StackPanel>
             </StackPanel>
-            <StackPanel Name="StackPanelOpponent" Width="218">
+            <StackPanel x:Name="StackPanelOpponent" Width="218">
                 <local:HearthstoneTextBlock x:Name="LblWinRateAgainst" FontSize="16" Text="VS: 0 - 0 (0%)" />
                 <local:DeckListView x:Name="ListViewOpponent" Height="auto" Canvas.Left="5" Canvas.Top="147"
-                                    Width="218" Background="{x:Null}" Foreground="White" BorderThickness="0"
-                                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                                    ScrollViewer.VerticalScrollBarVisibility="Disabled"
-                                    ScrollViewer.CanContentScroll="False" FontWeight="Bold" FontFamily="Arial">
-                    <ListView.Resources>
-                        <Style TargetType="GridViewColumnHeader">
+					Width="218" Background="{x:Null}" Foreground="White" BorderThickness="0"
+					ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+					ScrollViewer.VerticalScrollBarVisibility="Disabled"
+					ScrollViewer.CanContentScroll="False" FontWeight="Bold" FontFamily="Arial">
+                    <local:DeckListView.Resources>
+                        <Style TargetType="{x:Type GridViewColumnHeader}">
                             <Setter Property="Visibility" Value="Collapsed" />
                         </Style>
-                        <Style TargetType="ListViewItem">
+                        <Style TargetType="{x:Type ListViewItem}">
                             <Setter Property="Foreground" Value="{Binding ColorOpponent}" />
                             <Setter Property="Background" Value="{Binding Background}" />
                             <Setter Property="Height" Value="{Binding OpponentHeight}" />
                             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                             <Setter Property="Margin" Value="0,-2,0,0" />
                         </Style>
-                    </ListView.Resources>
+                    </local:DeckListView.Resources>
                 </local:DeckListView>
                 <local:HearthstoneTextBlock x:Name="LblOpponentDrawChance2" FontSize="16" Text="0%" />
                 <local:HearthstoneTextBlock x:Name="LblOpponentDrawChance1" FontSize="16" Text="0%" />
-                <StackPanel Name="StackPanelOpponentCount" Orientation="Horizontal" HorizontalAlignment="Center">
+                <StackPanel x:Name="StackPanelOpponentCount" Orientation="Horizontal" HorizontalAlignment="Center">
                     <local:HearthstoneTextBlock x:Name="LblOpponentCardCount" FontSize="14" Text="Hand: 0" />
                     <local:HearthstoneTextBlock x:Name="LblOpponentDeckCount" FontSize="14" Text="Deck: 0"
-                                                Margin="4,0,0,0" />
+						Margin="4,0,0,0" />
                 </StackPanel>
             </StackPanel>
 
-			<StackPanel Name="StackPanelSecrets" Width="auto" Height="auto" Visibility="Collapsed" />
+            <StackPanel x:Name="StackPanelSecrets" Width="auto" Height="auto" Visibility="Collapsed" />
 
             <UniformGrid x:Name="LblGrid" Width="300" Rows="1" HorizontalAlignment="Center" Canvas.Left="73"
-                         Canvas.Top="105">
-                <StackPanel Name="Marks0">
+				Canvas.Top="105">
+                <StackPanel x:Name="Marks0">
                     <local:HearthstoneTextBlock x:Name="LblCard0" FontSize="20" Text="0" />
                     <local:HearthstoneTextBlock x:Name="LblCardMark0" FontSize="20" Text="0" />
                 </StackPanel>
-                <StackPanel Name="Marks1">
+                <StackPanel x:Name="Marks1">
                     <local:HearthstoneTextBlock x:Name="LblCard1" FontSize="20" Text="0" />
                     <local:HearthstoneTextBlock x:Name="LblCardMark1" FontSize="20" Text="0" />
                 </StackPanel>
-                <StackPanel Name="Marks2">
+                <StackPanel x:Name="Marks2">
                     <local:HearthstoneTextBlock x:Name="LblCard2" FontSize="20" Text="0" />
                     <local:HearthstoneTextBlock x:Name="LblCardMark2" FontSize="20" Text="0" />
                 </StackPanel>
-                <StackPanel Name="Marks3">
+                <StackPanel x:Name="Marks3">
                     <local:HearthstoneTextBlock x:Name="LblCard3" FontSize="20" Text="0" />
                     <local:HearthstoneTextBlock x:Name="LblCardMark3" FontSize="20" Text="0" />
                 </StackPanel>
-                <StackPanel Name="Marks4">
+                <StackPanel x:Name="Marks4">
                     <local:HearthstoneTextBlock x:Name="LblCard4" FontSize="20" Text="0" />
                     <local:HearthstoneTextBlock x:Name="LblCardMark4" FontSize="20" Text="0" />
                 </StackPanel>
-                <StackPanel Name="Marks5">
+                <StackPanel x:Name="Marks5">
                     <local:HearthstoneTextBlock x:Name="LblCard5" FontSize="20" Text="0" />
                     <local:HearthstoneTextBlock x:Name="LblCardMark5" FontSize="20" Text="0" />
                 </StackPanel>
-                <StackPanel Name="Marks6">
+                <StackPanel x:Name="Marks6">
                     <local:HearthstoneTextBlock x:Name="LblCard6" FontSize="20" Text="0" />
                     <local:HearthstoneTextBlock x:Name="LblCardMark6" FontSize="20" Text="0" />
                 </StackPanel>
-                <StackPanel Name="Marks7">
+                <StackPanel x:Name="Marks7">
                     <local:HearthstoneTextBlock x:Name="LblCard7" FontSize="20" Text="0" />
                     <local:HearthstoneTextBlock x:Name="LblCardMark7" FontSize="20" Text="0" />
                 </StackPanel>
-                <StackPanel Name="Marks8">
+                <StackPanel x:Name="Marks8">
                     <local:HearthstoneTextBlock x:Name="LblCard8" FontSize="20" Text="0" />
                     <local:HearthstoneTextBlock x:Name="LblCardMark8" FontSize="20" Text="0" />
                 </StackPanel>
-                <StackPanel Name="Marks9">
+                <StackPanel x:Name="Marks9">
                     <local:HearthstoneTextBlock x:Name="LblCard9" FontSize="20" Text="0" />
                     <local:HearthstoneTextBlock x:Name="LblCardMark9" FontSize="20" Text="0" />
                 </StackPanel>
             </UniformGrid>
             <local:CardToolTip x:Name="ToolTipCard" Height="auto" Canvas.Left="323" Canvas.Top="203"
-                               Visibility="Hidden" />
-            <StackPanel Name="StackPanelAdditionalTooltips" Width="auto" Height="auto" Visibility="Collapsed" />
+				Visibility="Hidden" />
+            <StackPanel x:Name="StackPanelAdditionalTooltips" Width="auto" Height="auto" Visibility="Collapsed" />
+            <StackPanel x:Name="StackPanelMissingCards" Height="auto" Width="auto" Canvas.Left="5" Canvas.Top="57"  Visibility="Hidden">
+                <local:HearthstoneTextBlock x:Name="LblMissingCards" FontSize="12" Text=""/>
+                <Button x:Name="ButtonMissingCards" Content="OK"  Width="25" />
+            </StackPanel>
+            
         </Canvas>
 
     </Grid>

--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
@@ -260,9 +260,24 @@ namespace Hearthstone_Deck_Tracker
 			}
 
 			HideCardsWhenFriendsListOpen(PointFromScreen(_mousePos));
-
 			GrayOutSecrets(_mousePos);
+			HideMissingCardsStack(_mousePos);
 		}
+
+		private void HideMissingCardsStack (Point clickPos){
+
+			if(PointInsideControl(ButtonMissingCards.PointFromScreen(clickPos), ButtonMissingCards.ActualWidth,
+											   ButtonMissingCards.ActualHeight, new Thickness(5)))
+			{
+				_opponentCardsHidden = false;
+				StackPanelOpponent.Visibility = Visibility.Visible;
+				StackPanelMissingCards.Visibility = Visibility.Hidden;
+				UpdatePosition();
+			}
+
+
+		}
+
 
 		private async void HideCardsWhenFriendsListOpen(Point clickPos)
 		{
@@ -785,19 +800,40 @@ namespace Hearthstone_Deck_Tracker
 				{
 					var relativePos = PointFromScreen(new Point(pos.X, pos.Y));
 					if((StackPanelSecrets.IsVisible
-					    && (PointInsideControl(StackPanelSecrets.PointFromScreen(new Point(pos.X, pos.Y)), StackPanelSecrets.ActualWidth,
-					                           StackPanelSecrets.ActualHeight, new Thickness(20)))
-					    || relativePos.X < 170 && relativePos.Y > Height - 120))
+						&& (PointInsideControl(StackPanelSecrets.PointFromScreen(new Point(pos.X, pos.Y)), StackPanelSecrets.ActualWidth,
+											   StackPanelSecrets.ActualHeight, new Thickness(20)))
+						|| relativePos.X < 170 && relativePos.Y > Height - 120))
 					{
 						if(_mouseInput == null)
 							HookMouse();
 					}
 					else if(_mouseInput != null && !((_isFriendsListOpen.HasValue && _isFriendsListOpen.Value) || await Helper.FriendsListOpen()))
 						UnHookMouse();
+
+					//
+					if(StackPanelMissingCards.IsVisible && (PointInsideControl(ButtonMissingCards.PointFromScreen(new Point(pos.X, pos.Y)), ButtonMissingCards.ActualWidth,
+									   ButtonMissingCards.ActualHeight, new Thickness(20))))
+					{
+						if(_mouseInput == null)
+							HookMouse();
+						else if(_mouseInput != null)
+							UnHookMouse();
+					}
+
 				}
-				else if(_mouseInput != null)
-					UnHookMouse();
+				else
+				{
+					if(_mouseInput != null)
+						UnHookMouse();
+
+					if(StackPanelMissingCards.IsVisible && (PointInsideControl(ButtonMissingCards.PointFromScreen(new Point(pos.X, pos.Y)), ButtonMissingCards.ActualWidth,
+					   ButtonMissingCards.ActualHeight, new Thickness(20))))
+						HideMissingCardsStack(new Point(pos.X, pos.Y));
+
+				}
+
 			}
+
 		}
 
 
@@ -841,7 +877,7 @@ namespace Hearthstone_Deck_Tracker
 			//hide the overlay depenting on options
 			ShowOverlay(
 			            !((Config.Instance.HideInBackground && !User32.IsHearthstoneInForeground())
-			              || (Config.Instance.HideInMenu && Game.IsInMenu)
+						  || (Config.Instance.HideInMenu && Game.IsInMenu && !(StackPanelMissingCards.Visibility == Visibility.Visible))
 			              || (Config.Instance.HideOverlayInSpectator && Game.CurrentGameMode == GameMode.Spectator)
 			              || Config.Instance.HideOverlay || ForceHidden));
 
@@ -1137,6 +1173,24 @@ namespace Hearthstone_Deck_Tracker
 			_mouseInput.Dispose();
 			_mouseInput = null;
 			Logger.WriteLine("Disabled mouse hook");
+		}
+
+		public void ShowMissingCards(string message)
+		{
+			LblMissingCards.Text = message + System.Environment.NewLine;
+			if(Config.Instance.ExtraFeatures){
+				ButtonMissingCards.Width = 25;
+				ButtonMissingCards.Content = "OK";
+			}
+			else
+			{
+				ButtonMissingCards.Width = 130;
+				ButtonMissingCards.Content = "Mouseover to close";
+			}
+
+			StackPanelOpponent.Visibility = Visibility.Hidden;
+			_opponentCardsHidden = true;
+			StackPanelMissingCards.Visibility = Visibility.Visible;
 		}
 	}
 }


### PR DESCRIPTION
http://i.imgur.com/nmj6Hq8.jpg

If we run Hearthstone in widescreen (16:9 or 16:10...) we can use the blank space on the left to show the missing cards ingame. so it is easy to built them without sending back to windows.

If the option "extra Features" is enabled you can close it with a click on the button. (with lag)
If not the user can close it with a mouse-over.

I show the Missing cards even if the option "Hide in Menu" is set because if you export a Deck you want to see this and you can close it ingame.


