### PR TITLE
Update Card.InHandCount for PlayerDrawn deck.

### DIFF
--- a/Hearthstone Deck Tracker/Hearthstone/Game.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Game.cs
@@ -221,6 +221,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 				drawnCard = GetCardFromId(cardId);
 				PlayerDrawn.Add(drawnCard);
 			}
+			drawnCard.InHandCount++;
 			drawnCard.JustDrawn();
 
 
@@ -288,6 +289,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 					drawnCard.IsStolen = true;
 					PlayerDrawn.Add(drawnCard);
 				}
+				drawnCard.InHandCount++;
 				drawnCard.JustDrawn();
 
 				var deckCard = PlayerDeck.FirstOrDefault(c => c.Id == cardId && c.IsStolen);
@@ -317,6 +319,12 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 				card.InHandCount--;
 				if(CanRemoveCard(card))
 					PlayerDeck.Remove(card);
+			}
+
+			var drawnCard = PlayerDrawn.FirstOrDefault(c => c.Id == cardId);
+			if (drawnCard != null)
+			{
+				drawnCard.InHandCount--;
 			}
 		}
 


### PR DESCRIPTION
A single commit to address #601. Commit message copied below.

Originally, card drawn / play / get methods only updated
card.InHandCount for PlayerDeck, not PlayerDrawn. This commit updates
PlayerDrawn as well to make the "Use No Deck" overlay behavior more
consistent with the overlay behavior for when a pre-configured deck is
displayed. Specifically, cards in hand are now highlighted the same way
whether a pre-configured deck is used or not.