### PR TITLE
Save file dialog on EXPORT > SCREENSHOT and SAVE AS XML

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -606,7 +606,6 @@ namespace Hearthstone_Deck_Tracker
 		[DefaultValue(false)]
 		public bool WindowsTopmostIfHsForeground = false;
 
-		private string _currentLogFile;
 		private GameDetailsConfig _gameDetails;
 
 		public GameDetailsConfig GameDetails
@@ -658,11 +657,6 @@ namespace Hearthstone_Deck_Tracker
 			get { return Path.Combine(DataDir, "Replays"); }
 		}
 
-		public string LogFilePath
-		{
-			get { return Instance._currentLogFile ?? GetLogFileName(); }
-		}
-
 		public static Config Instance
 		{
 			get
@@ -690,14 +684,6 @@ namespace Hearthstone_Deck_Tracker
 
 		private Config()
 		{
-		}
-
-		private string GetLogFileName()
-		{
-			var date = DateTime.Now;
-			Instance._currentLogFile = string.Format("Logs/log_{0}{1}{2}-{3}{4}{5}.txt", date.Day, date.Month, date.Year, date.Hour, date.Minute,
-			                                         date.Second);
-			return _currentLogFile;
 		}
 
 		public static void Save()

--- a/Hearthstone Deck Tracker/FlyoutControls/Options.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options.xaml.cs
@@ -1390,12 +1390,19 @@ namespace Hearthstone_Deck_Tracker
 			Config.Save();
 		}
 
-		private void BtnSaveLog_OnClick(object sender, RoutedEventArgs e)
+		private async void BtnSaveLog_OnClick(object sender, RoutedEventArgs e)
 		{
-			Directory.CreateDirectory("Logs");
-			using(var sr = new StreamWriter(Config.Instance.LogFilePath, false))
-				sr.Write(TextBoxLog.Text);
-			Helper.MainWindow.ShowMessage("", "Saved log to file: " + Config.Instance.LogFilePath);
+			var date = DateTime.Now;
+			var logName = string.Format("log_{0}{1}{2}-{3}{4}{5}.txt", date.Day, date.Month, date.Year, date.Hour, date.Minute, date.Second);
+			var fileName = Helper.ShowSaveFileDialog(logName, "txt");
+
+			if (fileName != null)
+			{
+				using (var sr = new StreamWriter(fileName, false))
+					sr.Write(TextBoxLog.Text);
+
+				await Helper.MainWindow.ShowSavedFileMessage(fileName);
+			}
 		}
 
 		private void BtnClear_OnClick(object sender, RoutedEventArgs e)

--- a/Hearthstone Deck Tracker/MainWindow/MainWindow_Export.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow_Export.cs
@@ -73,11 +73,30 @@ namespace Hearthstone_Deck_Tracker
 			var dpiX = 96.0 * source.CompositionTarget.TransformToDevice.M11;
 			var dpiY = 96.0 * source.CompositionTarget.TransformToDevice.M22;
 
-			string fileName;
-			var saved = Helper.ScreenshotDeck(screenShotWindow, dpiX, dpiY, DeckList.Instance.ActiveDeckVersion.Name, out fileName);
+			var deckName = DeckList.Instance.ActiveDeckVersion.Name;
+			var pngEncoder = Helper.ScreenshotDeck(screenShotWindow.ListViewPlayer, dpiX, dpiY, deckName);
+			screenShotWindow.Shutdown();
 
-			if (saved)
-				await ShowSavedFileMessage(fileName);
+			if (pngEncoder != null)
+			{
+				var saveFileDialog = new SaveFileDialog();
+				saveFileDialog.FileName = deckName;
+				saveFileDialog.DefaultExt = ".png";
+				saveFileDialog.Filter = "PNG (*.png)|*.png";
+
+				bool? result = saveFileDialog.ShowDialog();
+
+				if (result == true)
+				{
+					var fileName = saveFileDialog.FileName;
+
+					using (var stream = new FileStream(fileName, FileMode.Create, FileAccess.Write))
+						pngEncoder.Save(stream);
+
+					await ShowSavedFileMessage(fileName);
+					Logger.WriteLine("Saved screenshot of " + deckName + " to file: " + fileName, "Export");
+				}
+			}
 		}
 
 		private async void BtnSaveToFile_OnClick(object sender, RoutedEventArgs e)

--- a/Hearthstone Deck Tracker/MainWindow/MainWindow_Export.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow_Export.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
-using Microsoft.Win32;
 using Hearthstone_Deck_Tracker.Hearthstone;
 using Hearthstone_Deck_Tracker.Windows;
 using MahApps.Metro.Controls.Dialogs;
@@ -79,14 +78,14 @@ namespace Hearthstone_Deck_Tracker
 
 			if (pngEncoder != null)
 			{
-				var fileName = ShowSaveFileDialog(deck.Name, "png");
+				var fileName = Helper.ShowSaveFileDialog(deck.Name, "png");
 
 				if (fileName != null)
 				{
 					using (var stream = new FileStream(fileName, FileMode.Create, FileAccess.Write))
 						pngEncoder.Save(stream);
 
-					await ShowSavedFileMessage(fileName);
+					await this.ShowSavedFileMessage(fileName);
 					Logger.WriteLine("Saved screenshot of " + deck.GetDeckInfo() + " to file: " + fileName, "Export");
 				}
 			}
@@ -98,29 +97,14 @@ namespace Hearthstone_Deck_Tracker
 			if(deck == null)
 				return;
 
-			var fileName = ShowSaveFileDialog(deck.Name, "xml");
+			var fileName = Helper.ShowSaveFileDialog(deck.Name, "xml");
 
 			if (fileName != null)
 			{
 				XmlManager<Deck>.Save(fileName, deck);
-				await ShowSavedFileMessage(fileName);
+				await this.ShowSavedFileMessage(fileName);
 				Logger.WriteLine("Saved " + deck.GetDeckInfo() + " to file: " + fileName, "Export");
 			}
-		}
-
-		private string ShowSaveFileDialog(string filename, string ext)
-		{
-			var saveFileDialog = new SaveFileDialog();
-			saveFileDialog.FileName = filename;
-			saveFileDialog.DefaultExt = string.Format("*.{0}", ext);
-			saveFileDialog.Filter = string.Format("{0} ({1})|{1}", ext.ToUpper(), saveFileDialog.DefaultExt);
-
-			bool? result = saveFileDialog.ShowDialog();
-
-			if (result == true)
-				return saveFileDialog.FileName;
-
-			return null;
 		}
 
 		private void BtnClipboard_OnClick(object sender, RoutedEventArgs e)
@@ -131,14 +115,6 @@ namespace Hearthstone_Deck_Tracker
 			Clipboard.SetText(Helper.DeckToIdString(deck));
 			this.ShowMessage("", "copied to clipboard");
 			Logger.WriteLine("Copied " + deck.GetDeckInfo() + " to clipboard", "Export");
-		}
-
-		public async Task ShowSavedFileMessage(string fileName)
-		{
-			var settings = new MetroDialogSettings {NegativeButtonText = "Open folder"};
-			var result = await this.ShowMessageAsync("", "Saved to\n\"" + fileName + "\"", MessageDialogStyle.AffirmativeAndNegative, settings);
-			if(result == MessageDialogResult.Negative)
-				Process.Start(Path.GetDirectoryName(fileName));
 		}
 
 		private async void BtnExportFromWeb_Click(object sender, RoutedEventArgs e)

--- a/Hearthstone Deck Tracker/Utility/Helper.cs
+++ b/Hearthstone Deck Tracker/Utility/Helper.cs
@@ -20,6 +20,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Hearthstone_Deck_Tracker.Enums;
 using Hearthstone_Deck_Tracker.Hearthstone;
+using Microsoft.Win32;
 using Color = System.Drawing.Color;
 using PixelFormat = System.Drawing.Imaging.PixelFormat;
 using Point = System.Drawing.Point;
@@ -131,8 +132,11 @@ namespace Hearthstone_Deck_Tracker
 			return result;
 		}
 
-		public static string ScreenshotDeck(DeckListView dlv, double dpiX, double dpiY, string name)
+		public static bool ScreenshotDeck(PlayerWindow screenShotWindow, double dpiX, double dpiY, string name, out string fileName)
 		{
+			fileName = "";
+			var dlv = screenShotWindow.ListViewPlayer;
+
 			try
 			{
 				var rtb = new RenderTargetBitmap((int)dlv.ActualWidth, (int)dlv.ActualHeight, dpiX, dpiY, PixelFormats.Pbgra32);
@@ -140,14 +144,29 @@ namespace Hearthstone_Deck_Tracker
 				var encoder = new PngBitmapEncoder();
 				encoder.Frames.Add(BitmapFrame.Create(rtb));
 
-				var path = GetValidFilePath("Screenshots", name, ".png");
-				using(var stream = new FileStream(path, FileMode.Create, FileAccess.Write))
-					encoder.Save(stream);
-				return path;
+				// Hide the screenshot window before we show the save file dialog
+				screenShotWindow.Shutdown();
+
+				var saveFileDialog = new SaveFileDialog();
+				saveFileDialog.FileName = name;
+				saveFileDialog.DefaultExt = ".png";
+				saveFileDialog.Filter = "PNG (*.png)|*.png";
+
+				bool? result = saveFileDialog.ShowDialog();
+
+				if (result == true)
+				{
+					fileName = saveFileDialog.FileName;
+
+					using (var stream = new FileStream(fileName, FileMode.Create, FileAccess.Write))
+						encoder.Save(stream);
+				}
+
+				return result == true;
 			}
 			catch(Exception)
 			{
-				return null;
+				return false;
 			}
 		}
 

--- a/Hearthstone Deck Tracker/Utility/Helper.cs
+++ b/Hearthstone Deck Tracker/Utility/Helper.cs
@@ -20,7 +20,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Hearthstone_Deck_Tracker.Enums;
 using Hearthstone_Deck_Tracker.Hearthstone;
-using Microsoft.Win32;
 using Color = System.Drawing.Color;
 using PixelFormat = System.Drawing.Imaging.PixelFormat;
 using Point = System.Drawing.Point;
@@ -132,41 +131,20 @@ namespace Hearthstone_Deck_Tracker
 			return result;
 		}
 
-		public static bool ScreenshotDeck(PlayerWindow screenShotWindow, double dpiX, double dpiY, string name, out string fileName)
+		public static PngBitmapEncoder ScreenshotDeck(DeckListView dlv, double dpiX, double dpiY, string name)
 		{
-			fileName = "";
-			var dlv = screenShotWindow.ListViewPlayer;
-
 			try
 			{
 				var rtb = new RenderTargetBitmap((int)dlv.ActualWidth, (int)dlv.ActualHeight, dpiX, dpiY, PixelFormats.Pbgra32);
 				rtb.Render(dlv);
+
 				var encoder = new PngBitmapEncoder();
 				encoder.Frames.Add(BitmapFrame.Create(rtb));
-
-				// Hide the screenshot window before we show the save file dialog
-				screenShotWindow.Shutdown();
-
-				var saveFileDialog = new SaveFileDialog();
-				saveFileDialog.FileName = name;
-				saveFileDialog.DefaultExt = ".png";
-				saveFileDialog.Filter = "PNG (*.png)|*.png";
-
-				bool? result = saveFileDialog.ShowDialog();
-
-				if (result == true)
-				{
-					fileName = saveFileDialog.FileName;
-
-					using (var stream = new FileStream(fileName, FileMode.Create, FileAccess.Write))
-						encoder.Save(stream);
-				}
-
-				return result == true;
+				return encoder;
 			}
 			catch(Exception)
 			{
-				return false;
+				return null;
 			}
 		}
 

--- a/Hearthstone Deck Tracker/Utility/Helper.cs
+++ b/Hearthstone Deck Tracker/Utility/Helper.cs
@@ -148,6 +148,21 @@ namespace Hearthstone_Deck_Tracker
 			}
 		}
 
+		public static string ShowSaveFileDialog(string filename, string ext)
+		{
+			var saveFileDialog = new Microsoft.Win32.SaveFileDialog();
+			saveFileDialog.FileName = filename;
+			saveFileDialog.DefaultExt = string.Format("*.{0}", ext);
+			saveFileDialog.Filter = string.Format("{0} ({1})|{1}", ext.ToUpper(), saveFileDialog.DefaultExt);
+
+			bool? result = saveFileDialog.ShowDialog();
+
+			if (result == true)
+				return saveFileDialog.FileName;
+
+			return null;
+		}
+
 		public static string GetValidFilePath(string dir, string name, string extension)
 		{
 			var validDir = RemoveInvalidPathChars(dir);

--- a/Hearthstone Deck Tracker/Windows/MessageDialogs.cs
+++ b/Hearthstone Deck Tracker/Windows/MessageDialogs.cs
@@ -51,6 +51,14 @@ namespace Hearthstone_Deck_Tracker.Windows
 			await window.ShowMessageAsync(title, message);
 		}
 
+		public static async Task ShowSavedFileMessage(this MainWindow window, string fileName)
+		{
+			var settings = new MetroDialogSettings { NegativeButtonText = "Open folder" };
+			var result = await window.ShowMessageAsync("", "Saved to\n\"" + fileName + "\"", MessageDialogStyle.AffirmativeAndNegative, settings);
+			if (result == MessageDialogResult.Negative)
+				Process.Start(Path.GetDirectoryName(fileName));
+		}
+
 		public static async Task ShowHsNotInstalledMessage(this MetroWindow window)
 		{
 			var settings = new MetroDialogSettings {AffirmativeButtonText = "Ok", NegativeButtonText = "Select manually"};


### PR DESCRIPTION
This changes `EXPORT > SCREENSHOT` and `EXPORT > SAVE AS XML` to present the user with a save file dialog, so they can choose where to save the files. This seems more natural and also allows the feature to work when the executable resides in %ProgramFiles% (issue #668).