### PR TITLE
Fix updater updating itself

### DIFF
--- a/Updater/Program.cs
+++ b/Updater/Program.cs
@@ -107,7 +107,7 @@ namespace Updater
 					var newFilePath = file.Replace(newPath, string.Empty);
 					Console.WriteLine("Writing {0}", newFilePath);
 					if(file.Contains("Updater"))
-						File.Copy(file, file.Replace("Updater", "Updater_new"));
+						File.Copy(file, newFilePath.Replace("Updater", "Updater_new"));
 					else
 						File.Copy(file, newFilePath, true);
 				}


### PR DESCRIPTION
This allows the updater to update itself. 

Previously wasn't copying the Updater_new.exe to the correct path.