### PR TITLE
Added Win-Loss count to NewDeckPicker

### DIFF
--- a/Hearthstone Deck Tracker/Controls/NewDeckPickerItem.xaml
+++ b/Hearthstone Deck Tracker/Controls/NewDeckPickerItem.xaml
@@ -16,7 +16,16 @@
                     </LinearGradientBrush>
                 </DockPanel.Background>
                 <Border BorderThickness="1"  BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" Width="48" DockPanel.Dock="Right" Margin="-1">
-                    <TextBlock Text="{Binding WinPercentString}" VerticalAlignment="Center" HorizontalAlignment="Center"  FontSize="12" FontWeight="Medium" Foreground="Black"/>
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <TextBlock Text="{Binding WinPercentString}" VerticalAlignment="Center" HorizontalAlignment="Center"  FontSize="12" FontWeight="Medium" Foreground="Black"/>
+                        <Viewbox Stretch="Uniform" StretchDirection="DownOnly" Grid.Row="1" Margin="2,0">
+                            <TextBlock Text="{Binding WinLossString}" VerticalAlignment="Center" HorizontalAlignment="Center"  FontSize="12" FontWeight="Medium" Foreground="Black" Grid.Row="1"/>
+                        </Viewbox>                        
+                    </Grid>                    
                 </Border>
                 <TextBlock Text="{Binding NameAndVersion}" TextTrimming="CharacterEllipsis" Margin="10,0" FontSize="14" FontWeight="{Binding SelectedFontWeight, RelativeSource={RelativeSource AncestorType=controls:NewDeckPickerItem}}" Foreground="Black" HorizontalAlignment="Center" VerticalAlignment="Center"/>
             </DockPanel>

--- a/Hearthstone Deck Tracker/Hearthstone/Deck.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Deck.cs
@@ -172,6 +172,20 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			}
 		}
 
+        [XmlIgnore]
+        public string WinLossString
+        {
+            get
+            {
+                var relevantGames = DeckStats.Games.Where(g => g.BelongsToDeckVerion(GetSelectedDeckVersion())).ToList();
+                if (DeckStats.Games.Count == 0)
+                    return "0-0";
+                return String.Format("{0}-{1}", 
+                    relevantGames.Count(g => g.Result == GameResult.Win),
+                    relevantGames.Count(g => g.Result == GameResult.Loss));
+            }
+        }
+
 		[XmlIgnore]
 		public string WinPercentString
 		{


### PR DESCRIPTION
I wanted to see actual win-loss counts for my decks, particularly for arena.

Textblock for WinPercentString was copied into a Viewbox to allow
scaling, so large numbers don't get clipped. Both Textblocks were moved
to a grid for positioning.