### PR TITLE
Added Fatigue counter that shows up once there are no cards in a deck.

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -192,6 +192,9 @@ namespace Hearthstone_Deck_Tracker
 		[DefaultValue(false)]
 		public bool HideOpponentCardCount = false;
 
+        [DefaultValue(false)]
+        public bool HideOpponentFatigueCount = false;
+
 		[DefaultValue(false)]
 		public bool HideOpponentCardMarks = false;
 
@@ -209,6 +212,9 @@ namespace Hearthstone_Deck_Tracker
 
 		[DefaultValue(false)]
 		public bool HidePlayerCardCount = false;
+
+        [DefaultValue(false)]
+        public bool HidePlayerFatigueCount = false;
 
 		[DefaultValue(false)]
 		public bool HidePlayerCards = false;
@@ -325,11 +331,11 @@ namespace Hearthstone_Deck_Tracker
 		[DefaultValue(false)]
 		public bool OwnsGoldenStalagg = false;
 
-		[DefaultValue(new[] {"Win Rate", "Cards", "Draw Chances", "Card Counter"})]
-		public string[] PanelOrderOpponent = {"Win Rate", "Cards", "Draw Chances", "Card Counter"};
+		[DefaultValue(new[] {"Win Rate", "Cards", "Draw Chances", "Card Counter", "Fatigue Counter"})]
+		public string[] PanelOrderOpponent = {"Win Rate", "Cards", "Draw Chances", "Card Counter", "Fatigue Counter"};
 
-		[DefaultValue(new[] {"Deck Title", "Wins", "Cards", "Draw Chances", "Card Counter"})]
-		public string[] PanelOrderPlayer = {"Deck Title", "Wins", "Cards", "Draw Chances", "Card Counter"};
+		[DefaultValue(new[] {"Deck Title", "Wins", "Cards", "Draw Chances", "Card Counter", "Fatigue Counter"})]
+		public string[] PanelOrderPlayer = {"Deck Title", "Wins", "Cards", "Draw Chances", "Card Counter", "Fatigue Counter"};
 
 		[DefaultValue(65)]
 		public double PlayerDeckHeight = 65;

--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -663,6 +663,18 @@ namespace Hearthstone_Deck_Tracker
 			Game.AddPlayToCurrentGame(PlayType.OpponentHeroPower, turn, cardId);
 		}
 
+        public static void HandlePlayerFatigue(int currentDamage)
+        {
+            LogEvent("PlayerFatigue", "", currentDamage);
+            Game.PlayerFatigueCount = currentDamage;
+        }
+
+        public static void HandleOpponentFatigue(int currentDamage)
+        {
+            LogEvent("OpponentFatigue", "", currentDamage);
+            Game.OpponentFatigueCount = currentDamage;
+        }
+
 		#region IGameHandlerImplementation
 
 		void IGameHandler.HandlePlayerBackToHand(string cardId, int turn)
@@ -819,6 +831,16 @@ namespace Hearthstone_Deck_Tracker
 		{
 			SetGameMode(mode);
 		}
+
+        void IGameHandler.HandlePlayerFatigue(int currentDamage)
+        {
+            HandlePlayerFatigue(currentDamage);
+        }
+
+        void IGameHandler.HandleOpponentFatigue(int currentDamage)
+        {
+            HandleOpponentFatigue(currentDamage);
+        }
 
 		#endregion IGameHandlerImplementation
 	}

--- a/Hearthstone Deck Tracker/Hearthstone/Game.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Game.cs
@@ -33,6 +33,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 
 		public static ObservableCollection<Card> OpponentCards;
 		public static int OpponentHandCount;
+        public static int OpponentFatigueCount;
 		public static bool IsInMenu;
 		public static bool IsUsingPremade;
 		public static int OpponentDeckCount;
@@ -58,6 +59,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 		public static ObservableCollection<Card> PlayerDeck;
 		public static ObservableCollection<Card> PlayerDrawn;
 		public static int PlayerHandCount;
+        public static int PlayerFatigueCount;
 		public static string PlayingAgainst;
 		public static string PlayingAs;
 		public static string PlayerName;
@@ -151,9 +153,11 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			OpponentId = -1;
 			SavedReplay = false;
 			PlayerHandCount = 0;
+            PlayerFatigueCount = 0;
 			OpponentSecretCount = 0;
 			OpponentCards.Clear();
 			OpponentHandCount = 0;
+            OpponentFatigueCount = 0;
 			OpponentDeckCount = 30;
 			SecondToLastUsedId = null;
 			OpponentHandAge = new int[MaxHandSize];
@@ -234,8 +238,8 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 				return true;
 
 			var drawnCard = PlayerDrawn.FirstOrDefault(c => c.Id == cardId);
-			if(drawnCard != null)
-				drawnCard.Count++;
+			if(drawnCard != null) 
+                drawnCard.Count++;
 			else
 			{
 				drawnCard = GetCardFromId(cardId);

--- a/Hearthstone Deck Tracker/HsLogReader.cs
+++ b/Hearthstone Deck Tracker/HsLogReader.cs
@@ -876,7 +876,14 @@ namespace Hearthstone_Deck_Tracker
 				}
 				else if(value == Game.OpponentId)
 					ProposeKeyPoint(KeyPointType.SecretStolen, id, ActivePlayer.Player);
-			}
+			} 
+            else if(tag == GAME_TAG.FATIGUE)
+            {
+                if (controller == Game.PlayerId)
+                    _gameHandler.HandlePlayerFatigue(Convert.ToInt32(rawValue));
+                else if (controller == Game.OpponentId)
+                    _gameHandler.HandleOpponentFatigue(Convert.ToInt32(rawValue));
+            }
 			if(_waitForController != null)
 			{
 				if(!isRecursive)

--- a/Hearthstone Deck Tracker/IGameHandler.cs
+++ b/Hearthstone Deck Tracker/IGameHandler.cs
@@ -34,6 +34,8 @@ namespace Hearthstone_Deck_Tracker
 		void SetGameMode(GameMode mode);
 		void HandleInMenu();
 		void HandleConcede();
+        void HandlePlayerFatigue(int currentDamage);
+        void HandleOpponentFatigue(int currentDamage);
 
 		void SetRank(int rank);
 

--- a/Hearthstone Deck Tracker/MainWindow/MainWindow_Load.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow_Load.cs
@@ -323,6 +323,19 @@ namespace Hearthstone_Deck_Tracker
 						converted = true;
 					}
 				}
+                if (configVersion <= new Version(0, 9, 6, 0))
+                {
+                    if(!Config.Instance.PanelOrderPlayer.Contains("Fatigue Counter"))
+                    {
+                        Config.Instance.Reset("PanelOrderPlayer");
+                        converted = true;
+                    }
+                    if (!Config.Instance.PanelOrderOpponent.Contains("Fatigue Counter"))
+                    {
+                        Config.Instance.Reset("PanelOrderOpponent");
+                        converted = true;
+                    }
+                }
 			}
 
 			if(converted)

--- a/Hearthstone Deck Tracker/MainWindow/MainWindow_Load.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow_Load.cs
@@ -40,6 +40,10 @@ namespace Hearthstone_Deck_Tracker
 						Options.ElementSorterPlayer.AddItem(new ElementSorterItem("Card Counter", !Config.Instance.HidePlayerCardCount,
 						                                                          value => Config.Instance.HidePlayerCardCount = !value, true));
 						break;
+                    case "Fatigue Counter":
+                        Options.ElementSorterPlayer.AddItem(new ElementSorterItem("Fatigue Counter", !Config.Instance.HidePlayerFatigueCount,
+						                                                          value => Config.Instance.HidePlayerFatigueCount = !value, true));
+						break;
 					case "Draw Chances":
 						Options.ElementSorterPlayer.AddItem(new ElementSorterItem("Draw Chances", !Config.Instance.HideDrawChances,
 						                                                          value => Config.Instance.HideDrawChances = !value, true));
@@ -66,6 +70,10 @@ namespace Hearthstone_Deck_Tracker
 						Options.ElementSorterOpponent.AddItem(new ElementSorterItem("Card Counter", !Config.Instance.HideOpponentCardCount,
 						                                                            value => Config.Instance.HideOpponentCardCount = !value, false));
 						break;
+                    case "Fatigue Counter":
+                        Options.ElementSorterOpponent.AddItem(new ElementSorterItem("Fatigue Counter", !Config.Instance.HideOpponentFatigueCount,
+                                                                                    value => Config.Instance.HideOpponentFatigueCount = !value, false));
+                        break;
 					case "Draw Chances":
 						Options.ElementSorterOpponent.AddItem(new ElementSorterItem("Draw Chances", !Config.Instance.HideOpponentDrawChances,
 						                                                            value => Config.Instance.HideOpponentDrawChances = !value, false));

--- a/Hearthstone Deck Tracker/Windows/OpponentWindow.xaml
+++ b/Hearthstone Deck Tracker/Windows/OpponentWindow.xaml
@@ -53,6 +53,9 @@
                 <local:HearthstoneTextBlock Margin="4,0,0,0" x:Name="LblOpponentDeckCount" Text="Deck: 0" FontSize="14"
                                             VerticalAlignment="Center" />
             </StackPanel>
+            <StackPanel Name="StackPanelOpponentFatigue" Orientation="Horizontal" HorizontalAlignment="Center">
+                <local:HearthstoneTextBlock x:Name="LblOpponentFatigue" FontSize="14" Text="" Margin="4,0,0,0" />
+            </StackPanel>
         </StackPanel>
     </Grid>
 </controls:MetroWindow>

--- a/Hearthstone Deck Tracker/Windows/OpponentWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/OpponentWindow.xaml.cs
@@ -105,6 +105,9 @@ namespace Hearthstone_Deck_Tracker
 					case "Card Counter":
 						StackPanelMain.Children.Add(StackPanelCount);
 						break;
+                    case "Fatigue Counter":
+                        StackPanelMain.Children.Add(StackPanelOpponentFatigue);
+                        break;
 					case "Win Rate":
 						StackPanelMain.Children.Add(LblWinRateAgainst);
 						break;
@@ -119,6 +122,8 @@ namespace Hearthstone_Deck_Tracker
 
 			if(cardsLeftInDeck <= 0)
 			{
+                LblOpponentFatigue.Text = "Next draw fatigues for: " + (Game.OpponentFatigueCount + 1);
+
 				LblOpponentDrawChance2.Text = cardCount <= 0 ? "[2]: -% / -%" : "[2]: 100% / -%";
 				LblOpponentDrawChance1.Text = cardCount <= 0 ? "[1]: -% / -%" : "[1]: 100% / -%";
 				return;

--- a/Hearthstone Deck Tracker/Windows/OpponentWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/OpponentWindow.xaml.cs
@@ -117,7 +117,6 @@ namespace Hearthstone_Deck_Tracker
 			LblOpponentCardCount.Text = "Hand: " + cardCount;
 			LblOpponentDeckCount.Text = "Deck: " + cardsLeftInDeck;
 
-
 			if(cardsLeftInDeck <= 0)
 			{
 				LblOpponentDrawChance2.Text = cardCount <= 0 ? "[2]: -% / -%" : "[2]: 100% / -%";

--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml
@@ -50,6 +50,9 @@
                     <local:HearthstoneTextBlock x:Name="LblCardCount" FontSize="14" Text="Hand: 0" />
                     <local:HearthstoneTextBlock x:Name="LblDeckCount" FontSize="14" Text="Deck: 0" Margin="4,0,0,0" />
                 </StackPanel>
+                <StackPanel Name="StackPanelPlayerFatigue" Orientation="Horizontal" HorizontalAlignment="Center">
+                    <local:HearthstoneTextBlock x:Name="LblPlayerFatigue" FontSize="14" Text="" Margin="4,0,0,0" />
+                </StackPanel>
             </StackPanel>
             <StackPanel Name="StackPanelOpponent" Width="218">
                 <local:HearthstoneTextBlock x:Name="LblWinRateAgainst" FontSize="16" Text="VS: 0 - 0 (0%)" />
@@ -75,8 +78,10 @@
                 <local:HearthstoneTextBlock x:Name="LblOpponentDrawChance1" FontSize="16" Text="0%" />
                 <StackPanel Name="StackPanelOpponentCount" Orientation="Horizontal" HorizontalAlignment="Center">
                     <local:HearthstoneTextBlock x:Name="LblOpponentCardCount" FontSize="14" Text="Hand: 0" />
-                    <local:HearthstoneTextBlock x:Name="LblOpponentDeckCount" FontSize="14" Text="Deck: 0"
-                                                Margin="4,0,0,0" />
+                    <local:HearthstoneTextBlock x:Name="LblOpponentDeckCount" FontSize="14" Text="Deck: 0" Margin="4,0,0,0" />
+                </StackPanel>
+                <StackPanel Name="StackPanelOpponentFatigue" Orientation="Horizontal" HorizontalAlignment="Center">
+                    <local:HearthstoneTextBlock x:Name="LblOpponentFatigue" FontSize="14" Text="" Margin="4,0,0,0" />
                 </StackPanel>
             </StackPanel>
 

--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
@@ -561,11 +561,13 @@ namespace Hearthstone_Deck_Tracker
 			LblDrawChance1.Visibility = Config.Instance.HideDrawChances ? Visibility.Collapsed : Visibility.Visible;
 			LblDrawChance2.Visibility = Config.Instance.HideDrawChances ? Visibility.Collapsed : Visibility.Visible;
 			LblCardCount.Visibility = Config.Instance.HidePlayerCardCount ? Visibility.Collapsed : Visibility.Visible;
+            LblPlayerFatigue.Visibility = Config.Instance.HidePlayerFatigueCount ? Visibility.Collapsed : Visibility.Visible;
 			LblDeckCount.Visibility = Config.Instance.HidePlayerCardCount ? Visibility.Collapsed : Visibility.Visible;
 
 			LblOpponentDrawChance1.Visibility = Config.Instance.HideOpponentDrawChances ? Visibility.Collapsed : Visibility.Visible;
 			LblOpponentDrawChance2.Visibility = Config.Instance.HideOpponentDrawChances ? Visibility.Collapsed : Visibility.Visible;
 			LblOpponentCardCount.Visibility = Config.Instance.HideOpponentCardCount ? Visibility.Collapsed : Visibility.Visible;
+            LblOpponentFatigue.Visibility = Config.Instance.HideOpponentFatigueCount ? Visibility.Collapsed : Visibility.Visible;
 			LblOpponentDeckCount.Visibility = Config.Instance.HideOpponentCardCount ? Visibility.Collapsed : Visibility.Visible;
 
 			ListViewOpponent.Visibility = Config.Instance.HideOpponentCards ? Visibility.Collapsed : Visibility.Visible;
@@ -926,9 +928,14 @@ namespace Hearthstone_Deck_Tracker
 						break;
 					case "Card Counter":
 						StackPanelPlayer.Children.Add(StackPanelPlayerCount);
-                        // TODO
+                        // TODO: Although it would make sense to use this here, 
+                        // it would be good to have it as a separate option.
+                        // I can't make it work the other way around though :s
                         StackPanelPlayer.Children.Add(StackPanelPlayerFatigue);
 						break;
+                    case "Fatigue Counter":
+                        StackPanelPlayer.Children.Add(StackPanelPlayerFatigue);
+                        break;
 					case "Deck Title":
 						StackPanelPlayer.Children.Add(LblDeckTitle);
 						break;
@@ -955,9 +962,14 @@ namespace Hearthstone_Deck_Tracker
 						break;
 					case "Card Counter":
 						StackPanelOpponent.Children.Add(StackPanelOpponentCount);
-                        // TODO
+                        // TODO: Although it would make sense to use this here, 
+                        // it would be good to have it as a separate option.
+                        // I can't make it work the other way around though :s
                         StackPanelOpponent.Children.Add(StackPanelOpponentFatigue);
-						break;
+                        break;
+                    case "Fatigue Counter":
+                        StackPanelOpponent.Children.Add(StackPanelOpponentFatigue);
+                        break;
 					case "Win Rate":
 						StackPanelOpponent.Children.Add(LblWinRateAgainst);
 						break;

--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
@@ -345,16 +345,17 @@ namespace Hearthstone_Deck_Tracker
 			LblOpponentCardCount.Text = "Hand: " + cardCount;
 			LblOpponentDeckCount.Text = "Deck: " + cardsLeftInDeck;
 
+            if (cardsLeftInDeck <= 0)
+            {
+                LblOpponentFatigue.Text = "Next draw fatigues for: " + (Game.OpponentFatigueCount + 1);
 
-			if(cardsLeftInDeck <= 0)
-			{
-				LblOpponentDrawChance2.Text = cardCount <= 0 ? "[2]: -% / -%" : "[2]: 100% / -%";
-				LblOpponentDrawChance1.Text = cardCount <= 0 ? "[1]: -% / -%" : "[1]: 100% / -%";
-				return;
-			}
+                LblOpponentDrawChance2.Text = cardCount <= 0 ? "[2]: -% / -%" : "[2]: 100% / -%";
+                LblOpponentDrawChance1.Text = cardCount <= 0 ? "[1]: -% / -%" : "[1]: 100% / -%";
+                return;
+            }
+            else LblOpponentFatigue.Text = "";
 
 			var handWithoutCoin = cardCount - (Game.OpponentHasCoin ? 1 : 0);
-
 
 			var holdingNextTurn2 = Math.Round(100.0f * Helper.DrawProbability(2, (cardsLeftInDeck + handWithoutCoin), handWithoutCoin + 1), 2);
 			var drawNextTurn2 = Math.Round(200.0f / cardsLeftInDeck, 2);
@@ -371,15 +372,19 @@ namespace Hearthstone_Deck_Tracker
 			if(_cardCount < cardCount)
 				Helper.SortCardCollection(ListViewPlayer.ItemsSource, Config.Instance.CardSortingClassFirst);
 			_cardCount = cardCount;
+
 			LblCardCount.Text = "Hand: " + cardCount;
 			LblDeckCount.Text = "Deck: " + cardsLeftInDeck;
 
-			if(cardsLeftInDeck <= 0)
-			{
-				LblDrawChance2.Text = "[2]: -%";
-				LblDrawChance1.Text = "[1]: -%";
-				return;
-			}
+            if(cardsLeftInDeck <= 0)
+            {
+                LblPlayerFatigue.Text = "Next draw fatigues for: " + (Game.PlayerFatigueCount + 1);
+
+                LblDrawChance2.Text = "[2]: -%";
+                LblDrawChance1.Text = "[1]: -%";
+                return;
+            }
+            else LblPlayerFatigue.Text = "";
 
 			LblDrawChance2.Text = "[2]: " + Math.Round(200.0f / cardsLeftInDeck, 2) + "%";
 			LblDrawChance1.Text = "[1]: " + Math.Round(100.0f / cardsLeftInDeck, 2) + "%";
@@ -921,6 +926,8 @@ namespace Hearthstone_Deck_Tracker
 						break;
 					case "Card Counter":
 						StackPanelPlayer.Children.Add(StackPanelPlayerCount);
+                        // TODO
+                        StackPanelPlayer.Children.Add(StackPanelPlayerFatigue);
 						break;
 					case "Deck Title":
 						StackPanelPlayer.Children.Add(LblDeckTitle);
@@ -948,6 +955,8 @@ namespace Hearthstone_Deck_Tracker
 						break;
 					case "Card Counter":
 						StackPanelOpponent.Children.Add(StackPanelOpponentCount);
+                        // TODO
+                        StackPanelOpponent.Children.Add(StackPanelOpponentFatigue);
 						break;
 					case "Win Rate":
 						StackPanelOpponent.Children.Add(LblWinRateAgainst);

--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
@@ -928,10 +928,6 @@ namespace Hearthstone_Deck_Tracker
 						break;
 					case "Card Counter":
 						StackPanelPlayer.Children.Add(StackPanelPlayerCount);
-                        // TODO: Although it would make sense to use this here, 
-                        // it would be good to have it as a separate option.
-                        // I can't make it work the other way around though :s
-                        StackPanelPlayer.Children.Add(StackPanelPlayerFatigue);
 						break;
                     case "Fatigue Counter":
                         StackPanelPlayer.Children.Add(StackPanelPlayerFatigue);
@@ -962,10 +958,6 @@ namespace Hearthstone_Deck_Tracker
 						break;
 					case "Card Counter":
 						StackPanelOpponent.Children.Add(StackPanelOpponentCount);
-                        // TODO: Although it would make sense to use this here, 
-                        // it would be good to have it as a separate option.
-                        // I can't make it work the other way around though :s
-                        StackPanelOpponent.Children.Add(StackPanelOpponentFatigue);
                         break;
                     case "Fatigue Counter":
                         StackPanelOpponent.Children.Add(StackPanelOpponentFatigue);

--- a/Hearthstone Deck Tracker/Windows/PlayerWindow.xaml
+++ b/Hearthstone Deck Tracker/Windows/PlayerWindow.xaml
@@ -57,6 +57,9 @@
                 <local:HearthstoneTextBlock Margin="4,0,0,0" x:Name="LblDeckCount" Text="Deck: 0" FontSize="14"
                                             VerticalAlignment="Center" />
             </StackPanel>
+            <StackPanel Name="StackPanelPlayerFatigue" Orientation="Horizontal" HorizontalAlignment="Center">
+                <local:HearthstoneTextBlock x:Name="LblPlayerFatigue" FontSize="14" Text="" Margin="4,0,0,0" />
+            </StackPanel>
         </StackPanel>
 
     </Grid>

--- a/Hearthstone Deck Tracker/Windows/PlayerWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/PlayerWindow.xaml.cs
@@ -130,6 +130,9 @@ namespace Hearthstone_Deck_Tracker
 					case "Card Counter":
 						StackPanelMain.Children.Add(StackPanelCount);
 						break;
+                    case "Fatigue Counter":
+                        StackPanelMain.Children.Add(StackPanelPlayerFatigue);
+                        break;
 					case "Deck Title":
 						StackPanelMain.Children.Add(LblDeckTitle);
 						break;
@@ -147,6 +150,8 @@ namespace Hearthstone_Deck_Tracker
 
 			if(cardsLeftInDeck <= 0)
 			{
+                LblPlayerFatigue.Text = "Next draw fatigues for: " + (Game.PlayerFatigueCount + 1);
+
 				LblDrawChance2.Text = "[2]: -%";
 				LblDrawChance1.Text = "[1]: -%";
 				return;


### PR DESCRIPTION
http://i.imgur.com/bFPI4wA.png

Hi there!
I tried to add this functionality since some times it is hard to keep track of the fatigue damage since the history on the left is so short.
The fatigue counter is located under the the card counter of each deck but only is displayed once the deck has 0 cards.
But I ran into a little problem. I'm not sure why, but I'm unable to set this counter as separate option (it just won't show up) so I ended up hooking it up to the card counter, meaning that whenever the card counter is enabled so is the fatigue counter. It makes sense, altough it is not correct in terms of implementation. I'm hoping once it gets merged someone can quickfix it or if someone could share some light in what I might be missing, I'd be grateful. 
Hope this is useful!