### PR TITLE
Don't put URL in note on import or sync

### DIFF
--- a/Hearthstone Deck Tracker/HearthStats/API/HearthStatsAPI.cs
+++ b/Hearthstone Deck Tracker/HearthStats/API/HearthStatsAPI.cs
@@ -708,13 +708,8 @@ namespace Hearthstone_Deck_Tracker.HearthStats.API
 		{
 			var note = deck.Note;
 			if(!string.IsNullOrEmpty(deck.Url))
-			{
-				var urlString = "[source=" + deck.Url + "]";
-				if(!deck.Note.Contains(deck.Url))
-					note += "\r\n" + urlString;
-				else if(deck.Note.Contains(deck.Url) && !deck.Note.Contains(urlString))
-					note = note.Replace(deck.Url, urlString);
-			}
+				note += "\r\n[HDT-source=" + deck.Url + "]";
+
 			return note;
 		}
 

--- a/Hearthstone Deck Tracker/HearthStats/API/Objects/DeckObject.cs
+++ b/Hearthstone Deck Tracker/HearthStats/API/Objects/DeckObject.cs
@@ -12,7 +12,7 @@ namespace Hearthstone_Deck_Tracker.HearthStats.API.Objects
 {
 	public class DeckObject
 	{
-		private const string noteRegex = @"\[source=(?<url>(.*?))\]";
+		private const string noteUrlRegex = @"\[(HDT-)?source=(?<url>(.*?))\]";
 		public int deck_version_id;
 		public int id;
 		public int klass_id;
@@ -27,13 +27,15 @@ namespace Hearthstone_Deck_Tracker.HearthStats.API.Objects
 				var url = "";
 				if(!string.IsNullOrEmpty(notes))
 				{
-					var match = Regex.Match(notes, noteRegex);
+					var match = Regex.Match(notes, noteUrlRegex);
 					if(match.Success)
 					{
 						url = match.Groups["url"].Value;
-						notes = Regex.Replace(notes, noteRegex, url);
+						notes = Regex.Replace(notes, noteUrlRegex, "");
 					}
 				}
+
+				notes = notes.Trim();
 
 				var deck = new Deck(name ?? "", Dictionaries.HeroDict[klass_id],
 				                    cards == null

--- a/Hearthstone Deck Tracker/MainWindow/MainWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow.xaml.cs
@@ -847,7 +847,6 @@ namespace Hearthstone_Deck_Tracker
 							if(isArenaDeck.HasValue)
 								deck.IsArenaDeck = isArenaDeck.Value;
 							deck.Url = url;
-							deck.Note = url;
 							deck.Name = deckName;
 							SetNewDeck(deck);
 							if(Config.Instance.AutoSaveOnImport)

--- a/Hearthstone Deck Tracker/MainWindow/MainWindow_Import.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow_Import.cs
@@ -35,9 +35,6 @@ namespace Hearthstone_Deck_Tracker
 				if(reimport) //keep old notes
 					deck.Note = _newDeck.Note;
 
-				if(!deck.Note.Contains(deck.Url))
-					deck.Note = deck.Url + "\n" + deck.Note;
-
 				SetNewDeck(deck, reimport);
 				TagControlEdit.SetSelectedTags(deck.Tags);
 				if(Config.Instance.AutoSaveOnImport)


### PR DESCRIPTION
Since the introduction of the 'open website' button, I assume we don't want to put the URL in the note anymore when importing from the web or NetDeck, or when we download decks from HearthStats.

I wanted to build on this commit in the archived decks branch, but it doesn't seem logically related to that feature so I created a separate pull request for it. This way the work is not going to be sitting in that branch for however long it's going to take to finish that feature off and be merged into master.

I also changed the tag we put into the HearthStats note to `[HDT-source=<url>]` rather than `[source=<url>]`. This is mainly because I want to use `[HDT-archived]` instead of `[archived]`, because it's more likely to not be used by the user (small chance but possible). So I thought to be consistent I'd change the URL tag too.

It still reads the `[source]` tag correctly though, since I've made the 'HDT-' prefix optional in the regex. This means it will still download decks correctly that users have previously synced to HearthStats, but new uploads will use `HDT-source` tag instead. It shouldn't result in any changes to user experience; it will simply be more consistent with the `[HDT-archived]` tag once that is added. If you don't like this whole thing though, I don't mind removing it and just sticking with `[source]` since it's not too important.