### PR TITLE
small features added: record opponent rank and breakdown by type cards left in deck 

### DIFF
--- a/Hearthstone Deck Tracker.sln
+++ b/Hearthstone Deck Tracker.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hearthstone Deck Tracker", "Hearthstone Deck Tracker\Hearthstone Deck Tracker.csproj", "{E63A3F1C-E662-4E62-BE43-AF27CB9E953D}"
 EndProject

--- a/Hearthstone Deck Tracker/Controls/DeckPicker.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/DeckPicker.xaml.cs
@@ -407,7 +407,7 @@ namespace Hearthstone_Deck_Tracker
 					orderedDecks = orderedDecks.OrderBy(x => x.TagList).ToList();
 					break;
 				case "Win Rate":
-					orderedDecks = orderedDecks.OrderByDescending(x => x.WinPercent).ToList();
+					orderedDecks = orderedDecks.OrderByDescending(x => x.WinPercentAll).ToList();
 					break;
 			}
 

--- a/Hearthstone Deck Tracker/Controls/DeckPickerItem.xaml
+++ b/Hearthstone Deck Tracker/Controls/DeckPickerItem.xaml
@@ -16,7 +16,7 @@
         </Grid.Background>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="50" />
+            <ColumnDefinition Width="70" />
         </Grid.ColumnDefinitions>
         <Label Content="{Binding WinPercentString}" Grid.Column="1" HorizontalAlignment="Center"
                VerticalAlignment="Center" FontSize="12" FontWeight="Medium" Foreground="Black" />

--- a/Hearthstone Deck Tracker/Controls/NewDeckPickerItem.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/NewDeckPickerItem.xaml.cs
@@ -55,7 +55,7 @@ namespace Hearthstone_Deck_Tracker.Controls
 
 		public double WinPercent
 		{
-			get { return Deck.WinPercent; }
+			get { return Deck.WinPercentAll; }
 		}
 
 		public string DeckName

--- a/Hearthstone Deck Tracker/FlyoutControls/DeckStatsControl.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/DeckStatsControl.xaml
@@ -369,6 +369,13 @@
                                                         </Style>
                                                     </DataGridTextColumn.ElementStyle>
                                                 </DataGridTextColumn>
+                                                <DataGridTextColumn Header="Opp. Rank" Binding="{Binding OpponentRankString}">
+                                                    <DataGridTextColumn.ElementStyle>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="HorizontalAlignment" Value="Center" />
+                                                        </Style>
+                                                    </DataGridTextColumn.ElementStyle>
+                                                </DataGridTextColumn>
                                                 <DataGridTextColumn Header="Result" Binding="{Binding ResultString}">
                                                     <DataGridTextColumn.ElementStyle>
                                                         <Style TargetType="TextBlock">

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayDeckWindows.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Overlay/OverlayDeckWindows.xaml.cs
@@ -1,5 +1,6 @@
 ﻿#region
 
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Windows;
@@ -202,8 +203,10 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Overlay
 				return;
 			Helper.MainWindow.PlayerWindow.Show();
 			Helper.MainWindow.PlayerWindow.Activate();
+            Dictionary<string, int> breakdownLeft = Helper.CalculateDeckBreakdown(Game.PlayerDeck);
 			Helper.MainWindow.PlayerWindow.SetCardCount(Game.PlayerHandCount,
-			                                            30 - Game.PlayerDrawn.Where(c => !c.IsStolen).Sum(card => card.Count));
+			                                            30 - Game.PlayerDrawn.Where(c => !c.IsStolen).Sum(card => card.Count),
+                                                        breakdownLeft);
 			Config.Instance.PlayerWindowOnStart = true;
 			Config.Save();
 		}

--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -440,28 +440,28 @@ namespace Hearthstone_Deck_Tracker
 
 				_lastGame = Game.CurrentGameStats;
 				selectedDeck.DeckStats.AddGameResult(_lastGame);
-				if(Config.Instance.ShowNoteDialogAfterGame && !Config.Instance.NoteDialogDelayed && !_showedNoteDialog)
-				{
-					_showedNoteDialog = true;
-					new NoteDialog(Game.CurrentGameStats);
-				}
 				Logger.WriteLine("Assigned current game to deck: " + selectedDeck.Name, "GameStats");
 				_assignedDeck = selectedDeck;
 
-				if(HearthStatsAPI.IsLoggedIn && Config.Instance.HearthStatsAutoUploadNewGames)
-				{
-					if(Game.CurrentGameMode == GameMode.None)
-						await GameModeDetection(300); //give the user 5 minutes to get out of the victory/defeat screen
-					if(Game.CurrentGameMode == GameMode.Casual)
-						await HsLogReader.Instance.RankedDetection();
-					if(Game.CurrentGameMode == GameMode.Ranked && !_lastGame.HasRank)
-						await RankDetection(5);
-					await GameModeSaved(15);
-					if(Game.CurrentGameMode == GameMode.Arena)
-						HearthStatsManager.UploadArenaMatchAsync(_lastGame, selectedDeck, background: true);
-					else
-						HearthStatsManager.UploadMatchAsync(_lastGame, selectedDeck, background: true);
-				}
+				if(Game.CurrentGameMode == GameMode.None)
+					await GameModeDetection(300); //give the user 5 minutes to get out of the victory/defeat screen
+				if(Game.CurrentGameMode == GameMode.Casual)
+					await HsLogReader.Instance.RankedDetection();
+				if(Game.CurrentGameMode == GameMode.Ranked && !_lastGame.HasRank)
+					await RankDetection(5);
+				await GameModeSaved(15);
+                if (HearthStatsAPI.IsLoggedIn && Config.Instance.HearthStatsAutoUploadNewGames)
+                {
+                    if (Game.CurrentGameMode == GameMode.Arena)
+                        HearthStatsManager.UploadArenaMatchAsync(_lastGame, selectedDeck, background: true);
+                    else
+                        HearthStatsManager.UploadMatchAsync(_lastGame, selectedDeck, background: true);
+                }
+                if (Config.Instance.ShowNoteDialogAfterGame && !Config.Instance.NoteDialogDelayed && !_showedNoteDialog)
+                {
+                    _showedNoteDialog = true;
+                    new NoteDialog(_lastGame);
+                }
 				_lastGame = null;
 			}
 			else

--- a/Hearthstone Deck Tracker/Hearthstone/Deck.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Deck.cs
@@ -184,12 +184,14 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			{
 				if(DeckStats.Games.Count == 0)
 					return "-";
-				return Math.Round(WinPercent, 0) + "%";
+				return 
+                    "Sel: " + Math.Round(WinPercentCurrentVersion, 0) + "%" + Environment.NewLine +
+                    "Tot: " + Math.Round(WinPercentAll, 0) + "%";
 			}
 		}
 
 		[XmlIgnore]
-		public double WinPercent
+		public double WinPercentAll
 		{
 			get
 			{
@@ -199,6 +201,30 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 				return 100.0 * relevantGames.Count(g => g.Result == GameResult.Win) / relevantGames.Count;
 			}
 		}
+
+        [XmlIgnore]
+        public double WinPercentCurrentVersion
+        {
+            get
+            {
+                if (DeckStats.Games.Count == 0)
+                {
+                    return 0.0;
+                }
+                double wonGamesCount = DeckStats.Games.Count(g => 
+                    g.Result == GameResult.Win 
+                    && (g.PlayerDeckVersion == SelectedVersion
+                        || (g.PlayerDeckVersion == null && Versions.Count == 0) //old decks before versioning
+                    )); 
+                double totalGamesCount = DeckStats.Games.Count(g => 
+                    (g.PlayerDeckVersion == SelectedVersion
+                        || (g.PlayerDeckVersion == null && Versions.Count == 0) //old decks before versioning
+                    ));
+                return 100.0 * 
+                     wonGamesCount
+                    / totalGamesCount;
+            }
+        }
 
 		[XmlIgnore]
 		public string GetClass

--- a/Hearthstone Deck Tracker/Stats/GameStats.cs
+++ b/Hearthstone Deck Tracker/Stats/GameStats.cs
@@ -67,6 +67,7 @@ namespace Hearthstone_Deck_Tracker.Stats
 		public string ReplayFile { get; set; }
 		public bool WasConceded { get; set; }
 		public int Rank { get; set; }
+        public int OpponentRank { get; set; }
 
 		public Guid DeckId
 		{
@@ -107,6 +108,18 @@ namespace Hearthstone_Deck_Tracker.Stats
 		{
 			get { return HasRank && GameMode == GameMode.Ranked ? Rank.ToString() : "-"; }
 		}
+
+        [XmlIgnore]
+        public bool HasOpponentRank
+        {
+            get { return OpponentRank > 0 && OpponentRank <= 25; }
+        }
+
+        [XmlIgnore]
+        public string OpponentRankString
+        {
+            get { return HasOpponentRank && GameMode == GameMode.Ranked ? OpponentRank.ToString() : "-"; }
+        }
 
 		[XmlIgnore]
 		public string ResultString

--- a/Hearthstone Deck Tracker/Utility/Helper.cs
+++ b/Hearthstone Deck Tracker/Utility/Helper.cs
@@ -296,8 +296,14 @@ namespace Hearthstone_Deck_Tracker
 			if(MainWindow.Overlay.IsVisible)
 				MainWindow.Overlay.Update(false);
 
+            Dictionary<string, int> breakdownLeft = CalculateDeckBreakdown(Game.PlayerDeck);
+
 			if(MainWindow.PlayerWindow.IsVisible)
-				MainWindow.PlayerWindow.SetCardCount(Game.PlayerHandCount, 30 - Game.PlayerDrawn.Sum(card => card.Count));
+				MainWindow.PlayerWindow.SetCardCount(
+                    Game.PlayerHandCount, 
+                    30 - Game.PlayerDrawn.Sum(card => card.Count),
+                    breakdownLeft   
+                    );
 
 			if(MainWindow.OpponentWindow.IsVisible)
 				MainWindow.OpponentWindow.SetOpponentCardCount(Game.OpponentHandCount, Game.OpponentDeckCount, Game.OpponentHasCoin);
@@ -390,5 +396,35 @@ namespace Hearthstone_Deck_Tracker
 				return FromUnixTime(time);
 			return DateTime.Now;
 		}
+
+        public static Dictionary<string, int> CalculateDeckBreakdown(IEnumerable<Card> cards)
+        {
+            List<string> allMechanics = cards.Where(c=> c.Mechanics != null).SelectMany(c => c.Mechanics).Distinct().ToList();
+            List<string> allRaces = cards.Where(c => c.Race != null).Select(c => c.Race).Distinct().ToList();
+            List<string> allTypes = cards.Where(c => c.Type != null).Select(c => c.Type).Distinct().ToList();
+
+            Dictionary<string, int> breakdownLeft = new Dictionary<string, int>();
+
+            foreach (string mechanic in allMechanics)
+            {
+                int left = cards.Where(card => ((card.Mechanics != null) && (card.Mechanics.Contains(mechanic)))).Sum(card => card.Count);
+                breakdownLeft.Add("(M)" + mechanic, left);
+            }
+
+            foreach (string race in allRaces)
+            {
+                int left = cards.Where(card => card.Race == race).Sum(card => card.Count);
+                breakdownLeft.Add("(R)" + race, left);
+            }
+
+            foreach (string type in allTypes)
+            {
+                int left = cards.Where(card => card.Type == type).Sum(card => card.Count);
+                breakdownLeft.Add("(T)" + type, left);
+            }
+
+            return breakdownLeft;
+        }
+
 	}
 }

--- a/Hearthstone Deck Tracker/Windows/NoteDialog.xaml
+++ b/Hearthstone Deck Tracker/Windows/NoteDialog.xaml
@@ -6,9 +6,44 @@
                       Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
                       BorderBrush="{DynamicResource AccentColorBrush}" BorderThickness="1"
                       WindowStartupLocation="CenterScreen">
-    <Grid>
-        <Button Content="Set" Margin="10,140,158,0" VerticalAlignment="Top" Click="Button_Click"/>
-        <TextBox Name="TextBoxNote" controls:TextBoxHelper.Watermark="Note..." Height="125" Margin="10,10,10,0"  PreviewKeyDown="TextBoxNote_OnPreviewKeyDown" TextWrapping="Wrap" Text="" VerticalAlignment="Top"/>
-        <CheckBox Name="CheckBoxEnterToSave" Content="Save with ENTER" HorizontalAlignment="Right" Margin="0,0,10,10" Width="123" Checked="CheckBoxEnterToSave_OnChecked" Unchecked="CheckBoxEnterToSave_OnUnchecked" VerticalAlignment="Bottom"/>
+    <Grid Name="FormGrid">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="107*"/>
+            <RowDefinition Height="28*"/>
+            <RowDefinition Height="30*"/>
+        </Grid.RowDefinitions>
+        <Button Content="Set" Margin="10,3.667,158,0" VerticalAlignment="Top" Click="Button_Click" Grid.Row="2" Height="20"/>
+        <TextBox Name="TextBoxNote" controls:TextBoxHelper.Watermark="Note..."  PreviewKeyDown="TextBoxNote_OnPreviewKeyDown" TextWrapping="Wrap" Text="" Margin="10,10,10,5"/>
+        <CheckBox Name="CheckBoxEnterToSave" Content="Save with ENTER" HorizontalAlignment="Right" Margin="0,0,10,9.667" Width="123" Checked="CheckBoxEnterToSave_OnChecked" Unchecked="CheckBoxEnterToSave_OnUnchecked" VerticalAlignment="Bottom" Grid.Row="2"/>
+        <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="10,2" Height="26">
+            <TextBlock Grid.Row="1" VerticalAlignment="Center">Opponent rank </TextBlock>
+            <ComboBox Name="ComboBoxOpponentRank" HorizontalAlignment="Left" Height="26" Margin="10,0,0,0" VerticalAlignment="Center" Grid.Row="1">
+                <ComboBoxItem>1</ComboBoxItem>
+                <ComboBoxItem>2</ComboBoxItem>
+                <ComboBoxItem>3</ComboBoxItem>
+                <ComboBoxItem>4</ComboBoxItem>
+                <ComboBoxItem>5</ComboBoxItem>
+                <ComboBoxItem>6</ComboBoxItem>
+                <ComboBoxItem>7</ComboBoxItem>
+                <ComboBoxItem>8</ComboBoxItem>
+                <ComboBoxItem>9</ComboBoxItem>
+                <ComboBoxItem>10</ComboBoxItem>
+                <ComboBoxItem>11</ComboBoxItem>
+                <ComboBoxItem>12</ComboBoxItem>
+                <ComboBoxItem>13</ComboBoxItem>
+                <ComboBoxItem>14</ComboBoxItem>
+                <ComboBoxItem>15</ComboBoxItem>
+                <ComboBoxItem>16</ComboBoxItem>
+                <ComboBoxItem>17</ComboBoxItem>
+                <ComboBoxItem>18</ComboBoxItem>
+                <ComboBoxItem>19</ComboBoxItem>
+                <ComboBoxItem>20</ComboBoxItem>
+                <ComboBoxItem>21</ComboBoxItem>
+                <ComboBoxItem>22</ComboBoxItem>
+                <ComboBoxItem>23</ComboBoxItem>
+                <ComboBoxItem>24</ComboBoxItem>
+                <ComboBoxItem>25</ComboBoxItem>
+            </ComboBox>
+        </StackPanel>
     </Grid>
 </controls:MetroWindow>

--- a/Hearthstone Deck Tracker/Windows/NoteDialog.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/NoteDialog.xaml.cs
@@ -16,16 +16,24 @@ namespace Hearthstone_Deck_Tracker
 		private readonly GameStats _game;
 		private readonly bool _initialized;
 
-		public NoteDialog(GameStats game)
-		{
-			InitializeComponent();
-			_game = game;
-			CheckBoxEnterToSave.IsChecked = Config.Instance.EnterToSaveNote;
-			Show();
-			Activate();
-			TextBoxNote.Focus();
-			_initialized = true;
-		}
+        public NoteDialog(GameStats game)
+        {
+            InitializeComponent();
+            _game = game;
+            CheckBoxEnterToSave.IsChecked = Config.Instance.EnterToSaveNote;
+            Show();
+            Activate();
+            TextBoxNote.Focus();
+            if (game.GameMode == Enums.GameMode.Ranked)
+            {
+                ComboBoxOpponentRank.SelectedIndex = game.Rank - 1;
+            }
+            else
+            {
+                FormGrid.RowDefinitions[1].Height = new GridLength(0);
+            }            
+            _initialized = true;
+        }
 
 		private void Button_Click(object sender, RoutedEventArgs e)
 		{
@@ -37,7 +45,11 @@ namespace Hearthstone_Deck_Tracker
 			if(_game != null)
 			{
 				_game.Note = TextBoxNote.Text;
-				DeckStatsList.Save();
+                if (_game.GameMode == Enums.GameMode.Ranked)
+                {
+                    _game.OpponentRank = ComboBoxOpponentRank.SelectedIndex + 1;
+                }
+                DeckStatsList.Save();
 				(Config.Instance.StatsInWindow ? Helper.MainWindow.StatsWindow.StatsControl : Helper.MainWindow.DeckStatsFlyout).Refresh();
 			}
 			Close();

--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml
@@ -46,6 +46,8 @@
                     <local:HearthstoneTextBlock x:Name="LblDrawChance2" FontSize="16" Text="0%" />
                     <local:HearthstoneTextBlock x:Name="LblDrawChance1" FontSize="16" Text="0%" Margin="4,0,0,0" />
                 </StackPanel>
+                <StackPanel Name="StackPanelDrawType" Orientation="Vertical" HorizontalAlignment="Center">
+                </StackPanel>
                 <StackPanel Name="StackPanelPlayerCount" Orientation="Horizontal" HorizontalAlignment="Center">
                     <local:HearthstoneTextBlock x:Name="LblCardCount" FontSize="14" Text="Hand: 0" />
                     <local:HearthstoneTextBlock x:Name="LblDeckCount" FontSize="14" Text="Deck: 0" Margin="4,0,0,0" />

--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
@@ -366,7 +366,7 @@ namespace Hearthstone_Deck_Tracker
 			LblOpponentDrawChance1.Text = "[1]: " + holdingNextTurn + "% / " + drawNextTurn + "%";
 		}
 
-		private void SetCardCount(int cardCount, int cardsLeftInDeck)
+        private void SetCardCount(int cardCount, int cardsLeftInDeck, Dictionary<string, int> breakdownLeft)
 		{
 			//previous < current -> draw
 			if(_cardCount < cardCount)
@@ -388,7 +388,20 @@ namespace Hearthstone_Deck_Tracker
 
 			LblDrawChance2.Text = "[2]: " + Math.Round(200.0f / cardsLeftInDeck, 2) + "%";
 			LblDrawChance1.Text = "[1]: " + Math.Round(100.0f / cardsLeftInDeck, 2) + "%";
-		}
+            StackPanelDrawType.Children.Clear();
+
+            foreach (var item in breakdownLeft)
+            {
+                HearthstoneTextBlock htb = new HearthstoneTextBlock();
+                htb.Text = string.Format("{0} : ({1}) {2}%",
+                    item.Key,
+                    item.Value,
+                    Math.Round(100.0f * item.Value / cardsLeftInDeck, 2)
+                    );
+                htb.FontSize = 14;
+                StackPanelDrawType.Children.Add(htb);
+            }
+        }
 
 		public void ShowOverlay(bool enable)
 		{
@@ -578,7 +591,12 @@ namespace Hearthstone_Deck_Tracker
 			DebugViewer.Visibility = Config.Instance.Debug ? Visibility.Visible : Visibility.Hidden;
 			DebugViewer.Width = (Width * Config.Instance.TimerLeft / 100);
 
-			SetCardCount(Game.PlayerHandCount, 30 - Game.PlayerDrawn.Where(c => !c.IsStolen).Sum(c => c.Count));
+            Dictionary<string, int> breakdownLeft = Helper.CalculateDeckBreakdown(Game.PlayerDeck);
+
+            SetCardCount(Game.PlayerHandCount,
+                         30 - Game.PlayerDrawn.Where(c => !c.IsStolen).Sum(c => c.Count),
+                         breakdownLeft
+                         );
 
 			SetOpponentCardCount(Game.OpponentHandCount, Game.OpponentDeckCount);
 
@@ -899,6 +917,7 @@ namespace Hearthstone_Deck_Tracker
 						break;
 					case "Draw Chances":
 						StackPanelPlayer.Children.Add(StackPanelPlayerDraw);
+                        StackPanelPlayer.Children.Add(StackPanelDrawType);
 						break;
 					case "Card Counter":
 						StackPanelPlayer.Children.Add(StackPanelPlayerCount);

--- a/Hearthstone Deck Tracker/Windows/PlayerWindow.xaml
+++ b/Hearthstone Deck Tracker/Windows/PlayerWindow.xaml
@@ -51,6 +51,8 @@
                 <local:HearthstoneTextBlock Margin="4,0,0,0" x:Name="LblDrawChance1" Text="0%" FontSize="16"
                                             VerticalAlignment="Center" />
             </StackPanel>
+            <StackPanel Name="StackPanelDrawType" Orientation="Vertical" HorizontalAlignment="Center">
+            </StackPanel>
             <StackPanel Name="StackPanelCount" Orientation="Horizontal" HorizontalAlignment="Center">
                 <local:HearthstoneTextBlock x:Name="LblCardCount" Text="Hand: 0" FontSize="14"
                                             VerticalAlignment="Center" />

--- a/Hearthstone Deck Tracker/Windows/PlayerWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/PlayerWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿#region
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -112,7 +113,8 @@ namespace Hearthstone_Deck_Tracker
 						break;
 					case "Draw Chances":
 						StackPanelMain.Children.Add(StackPanelDraw);
-						break;
+                        StackPanelMain.Children.Add(StackPanelDrawType);
+                		break;
 					case "Card Counter":
 						StackPanelMain.Children.Add(StackPanelCount);
 						break;
@@ -129,7 +131,7 @@ namespace Hearthstone_Deck_Tracker
 			}
 		}
 
-		public void SetCardCount(int cardCount, int cardsLeftInDeck)
+		public void SetCardCount(int cardCount, int cardsLeftInDeck, Dictionary<string, int> breakdownLeft)
 		{
 			LblCardCount.Text = "Hand: " + cardCount;
 			LblDeckCount.Text = "Deck: " + cardsLeftInDeck;
@@ -145,7 +147,21 @@ namespace Hearthstone_Deck_Tracker
 
 			LblDrawChance2.Text = "[2]: " + Math.Round(200.0f / cardsLeftInDeck, 2) + "%";
 			LblDrawChance1.Text = "[1]: " + Math.Round(100.0f / cardsLeftInDeck, 2) + "%";
-		}
+            
+            StackPanelDrawType.Children.Clear();
+            foreach (var item in breakdownLeft)
+            {
+                HearthstoneTextBlock htb = new HearthstoneTextBlock();
+                htb.Text = string.Format("{0} : ({1}) {2}%", 
+                    item.Key,
+                    item.Value,
+                    Math.Round(100.0f * item.Value / cardsLeftInDeck, 2)
+                    );
+                htb.FontSize = 16;
+                StackPanelDrawType.Children.Add(htb);
+                StackPanelDrawType.UpdateLayout();
+            }
+        }
 
 		private void PlayerDeckOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)
 		{
@@ -209,13 +225,15 @@ namespace Hearthstone_Deck_Tracker
 			if(top)
 			{
 				StackPanelMain.Children.Add(StackPanelDraw);
-				StackPanelMain.Children.Add(StackPanelCount);
+                StackPanelMain.Children.Add(StackPanelDrawType);
+                StackPanelMain.Children.Add(StackPanelCount);
 				StackPanelMain.Children.Add(ListViewPlayer);
 			}
 			else
 			{
 				StackPanelMain.Children.Add(ListViewPlayer);
 				StackPanelMain.Children.Add(StackPanelDraw);
+                StackPanelMain.Children.Add(StackPanelDrawType);				
 				StackPanelMain.Children.Add(StackPanelCount);
 			}
 		}


### PR DESCRIPTION
3 changes:
 - on gameplay overlay, added breakdown of left cards by mechanic
 - added opponent rank to note screen. I had to change when note form is displayed to achieve that - you have to leave match result screen before you get your rank and game type.
 - in deck list display win% for total and selected version (i just have seen you added option related to this display, so this might not be relevant anymore)
