### PR TITLE
Extract method refactor for OnSelectedDeckChanged

### DIFF
--- a/Hearthstone Deck Tracker/MainWindow/MainWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow.xaml.cs
@@ -313,10 +313,7 @@ namespace Hearthstone_Deck_Tracker
 			//UseDeck(lastDeck);
 			//}
 			if(DeckList.Instance.ActiveDeck != null)
-			{
-				SetupNotesAndStats(DeckList.Instance.ActiveDeck);
-				UseDeck(DeckList.Instance.ActiveDeck);
-			}
+				SelectDeck(DeckList.Instance.ActiveDeck);
 
 			if(_foundHsDirectory)
 				HsLogReader.Instance.Start();
@@ -1037,11 +1034,30 @@ namespace Hearthstone_Deck_Tracker
 
 		private void DeckPickerList_OnSelectedDeckChanged(NewDeckPicker sender, Deck deck)
 		{
+			SelectDeck(deck);
+		}
+
+		public void SelectDeck(Deck deck)
+		{
 			if(deck != null)
 			{
-				SetupNotesAndStats(deck);
-				UseDeck(deck);
-				Game.IsUsingPremade = true;
+				//set up notes
+				DeckNotesEditor.SetDeck(deck);
+				var flyoutHeader = deck.Name.Length >= 20 ? string.Join("", deck.Name.Take(17)) + "..." : deck.Name;
+				FlyoutNotes.Header = flyoutHeader;
+
+				//set up stats
+				if(Config.Instance.StatsInWindow)
+				{
+					StatsWindow.Title = "Stats: " + deck.Name;
+					StatsWindow.StatsControl.SetDeck(deck);
+				}
+				else
+				{
+					FlyoutDeckStats.Header = "Stats: " + deck.Name;
+					DeckStatsFlyout.SetDeck(deck);
+				}
+
 				//change player deck itemsource
 				if(Overlay.ListViewPlayer.ItemsSource != Game.PlayerDeck)
 				{
@@ -1051,6 +1067,8 @@ namespace Hearthstone_Deck_Tracker
 					PlayerWindow.ListViewPlayer.Items.Refresh();
 					Logger.WriteLine("Set player itemsource as playerdeck", "Tracker");
 				}
+
+				UseDeck(deck);
 				UpdateDeckList(deck);
 				Logger.WriteLine("Switched to deck: " + deck.Name, "Tracker");
 
@@ -1111,29 +1129,6 @@ namespace Hearthstone_Deck_Tracker
 			HsLogReader.Instance.Reset(true);
 			Overlay.Update(false);
 			Overlay.SortViews();
-		}
-
-		private void SetupNotesAndStats(Deck selected)
-		{
-			if(selected == null)
-				return;
-
-			//set up notes
-			DeckNotesEditor.SetDeck(selected);
-			var flyoutHeader = selected.Name.Length >= 20 ? string.Join("", selected.Name.Take(17)) + "..." : selected.Name;
-			FlyoutNotes.Header = flyoutHeader;
-
-			//set up stats
-			if(Config.Instance.StatsInWindow)
-			{
-				StatsWindow.Title = "Stats: " + selected.Name;
-				StatsWindow.StatsControl.SetDeck(selected);
-			}
-			else
-			{
-				FlyoutDeckStats.Header = "Stats: " + selected.Name;
-				DeckStatsFlyout.SetDeck(selected);
-			}
 		}
 
 		public void UpdateDeckList(Deck selected)

--- a/Hearthstone Deck Tracker/MainWindow/MainWindow_Load.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow_Load.cs
@@ -623,18 +623,6 @@ namespace Hearthstone_Deck_Tracker
 			MenuItemCheckBoxAutoSyncBackground.IsChecked = Config.Instance.HearthStatsAutoSyncInBackground;
 			MenuItemCheckBoxAutoDeleteDecks.IsChecked = Config.Instance.HearthStatsAutoDeleteDecks;
 			MenuItemCheckBoxAutoDeleteGames.IsChecked = Config.Instance.HearthStatsAutoDeleteMatches;
-
-			UpdatePanelVersionComboBox(DeckList.Instance.ActiveDeck);
-			if(DeckList.Instance.ActiveDeck != null && Overlay.ListViewPlayer.ItemsSource != Game.PlayerDeck)
-			{
-				Overlay.ListViewPlayer.ItemsSource = Game.PlayerDeck;
-				Overlay.ListViewPlayer.Items.Refresh();
-				PlayerWindow.ListViewPlayer.ItemsSource = Game.PlayerDeck;
-				PlayerWindow.ListViewPlayer.Items.Refresh();
-				Logger.WriteLine("Set player itemsource as playerdeck", "Tracker");
-			}
-			ManaCurveMyDecks.SetDeck(DeckList.Instance.ActiveDeck);
-			EnableMenuItems(DeckList.Instance.ActiveDeck != null);
 		}
 
 		public void UpdateQuickFilterItemSource()


### PR DESCRIPTION
This is a better fix for what I did in [pull/746](https://github.com/Epix37/Hearthstone-Deck-Tracker/pull/746).

I've extracted out the `OnSelectedDeckChanged` implementation to another method and now call that method on start. This allows us to remove the `SetupNotesAndStats` method, and remove the extra stuff at the end of `LoadConfig` that never really felt like it belonged there.

I think everything gets set up correctly on start now just as it would when you choose a deck from the deck picker. I had to reorder some things in the extracted method to make sure the cards were sorted in the right order in the overlay on start, so hopefully this doesn't introduce any more bugs like that that I'm not seeing, but I think it's fine.