### PR TITLE
Fix deck note syncing when selected deck changes

### DIFF
--- a/Hearthstone Deck Tracker/FlyoutControls/DeckNotes.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/DeckNotes.xaml.cs
@@ -24,6 +24,7 @@ namespace Hearthstone_Deck_Tracker
 
 		public void SetDeck(Deck deck)
 		{
+			SaveDeck();
 			_currentDeck = deck;
 			Textbox.Text = deck.Note;
 			_noteChanged = false;
@@ -44,7 +45,7 @@ namespace Hearthstone_Deck_Tracker
 
 		public void SaveDeck()
 		{
-			if(!_noteChanged)
+			if(!_noteChanged || _currentDeck == null)
 				return;
 			DeckList.Save();
 			if(Config.Instance.HearthStatsAutoUploadNewDecks)


### PR DESCRIPTION
Editing deck note now triggers sync properly when the selected deck changes while the notes flyout is still open.