### PR TITLE
Fix syncing old deck metadata

### DIFF
--- a/Hearthstone Deck Tracker/HearthStats/API/HearthStatsManager.cs
+++ b/Hearthstone Deck Tracker/HearthStats/API/HearthStatsManager.cs
@@ -256,13 +256,12 @@ namespace Hearthstone_Deck_Tracker.HearthStats.API
 					}
 				}
 			}
-			var notes = HearthStatsAPI.AddSpecialTagsToNote(deck);
-			var result = await HearthStatsAPI.PostDeckAsync(first, notes);
+			var result = await HearthStatsAPI.PostDeckAsync(first, deck);
 			if(!result.Success && result.Retry)
 			{
 				await Task.Delay(RetryDelay);
 				Logger.WriteLine("try #2 to upload deck " + deck, "HearthStatsManager");
-				result = await HearthStatsAPI.PostDeckAsync(first, notes);
+				result = await HearthStatsAPI.PostDeckAsync(first, deck);
 			}
 			if(result.Success)
 			{


### PR DESCRIPTION
Fix syncing deck name and tags of v1.0 rather than of latest version of the deck, since this might be old metadata that has since been changed.

This was the same problem as the old note being synced, so should have noticed it at the time. The old bug could be reproduced by: Logout of HearthStats. Create a new deck. Edit deck to v1.1. Change the name of deck (resave as 1.1 again). Change tags. Login to Hearthstats and sync. It will upload the old deck name and no tags (or whatever the old tags were).