### PR TITLE
Refactor DeselectDeck into SelectDeck(null) code path

### DIFF
--- a/Hearthstone Deck Tracker/Controls/DeckPicker.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/DeckPicker.xaml.cs
@@ -439,7 +439,7 @@ namespace Hearthstone_Deck_Tracker
 				return;
 			if(Equals(deck, SelectedDeck))
 			{
-				Helper.MainWindow.DeselectDeck();
+				Helper.MainWindow.SelectDeck(null);
 				e.Handled = true;
 			}
 		}

--- a/Hearthstone Deck Tracker/MainWindow/MainWindow_Edit.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow_Edit.cs
@@ -39,7 +39,7 @@ namespace Hearthstone_Deck_Tracker
 			if(result == MessageDialogResult.Negative)
 				return;
 
-			DeselectDeck();
+			SelectDeck(null);
 			DeleteDeck(deck);
 		}
 

--- a/Hearthstone Deck Tracker/MainWindow/MainWindow_NewDeck.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow_NewDeck.cs
@@ -321,7 +321,7 @@ namespace Hearthstone_Deck_Tracker
 			if(deck != null)
 			{
 				ClearNewDeckSection();
-				DeselectDeck();
+				SelectDeck(null);
 				EditingDeck = editing;
 				if(editing)
 				{
@@ -475,7 +475,7 @@ namespace Hearthstone_Deck_Tracker
 			if(result == MessageDialogResult.Negative)
 				_newDeck.IsArenaDeck = true;
 
-			DeselectDeck();
+			SelectDeck(null);
 			ExpandNewDeck();
 			ListViewDeck.ItemsSource = _newDeck.Cards;
 			UpdateDeckHistoryPanel(_newDeck, true);


### PR DESCRIPTION
This moves the `MainWindow.DeselectDeck` code into the `SelectDeck(null)` code path. Think this reduces some code duplication.

Also fixes a bug where the version combo box was still visible after you click `TRACKER > USE NO DECK`.