### PR TITLE
Fix card lock detection

### DIFF
--- a/Hearthstone Deck Tracker/DeckExporter.cs
+++ b/Hearthstone Deck Tracker/DeckExporter.cs
@@ -279,7 +279,7 @@ namespace Hearthstone_Deck_Tracker
 		{
 			const int width = 55;
 			const int height = 30;
-			const double maxBrightness = 5 / 11;
+			const double maxBrightness = 5.0 / 11.0;
 
 			var capture = Helper.CaptureHearthstone(new Point(posX, posY), width, height, wndHandle);
 			if(capture == null)


### PR DESCRIPTION
The CardHasLock method was always returning false due to maxBrightness being incorrectly set to 0.