### PR TITLE
Exporter now remembers text in clipboard and restores it if "Paste names from clipboard" option is used.

### DIFF
--- a/Hearthstone Deck Tracker/DeckExporter.cs
+++ b/Hearthstone Deck Tracker/DeckExporter.cs
@@ -18,8 +18,12 @@ namespace Hearthstone_Deck_Tracker
 		{
 			if(deck == null)
 				return;
+            string Current_Clipboard = "";
+
 			try
 			{
+                if (Config.Instance.ExportPasteClipboard && Clipboard.ContainsText())
+                    Current_Clipboard = Clipboard.GetText();
 				Logger.WriteLine(string.Format("Exporting " + deck.GetDeckInfo()), "DeckExporter");
 				var hsHandle = User32.GetHearthstoneWindow();
 
@@ -100,6 +104,8 @@ namespace Hearthstone_Deck_Tracker
 			{
 				Helper.MainWindow.Overlay.ForceHidden = false;
 				Helper.MainWindow.Overlay.UpdatePosition();
+                if (Config.Instance.ExportPasteClipboard && Current_Clipboard != "")
+                    Clipboard.SetText(Current_Clipboard);
 			}
 		}
 


### PR DESCRIPTION
Just added this simple change to remember text in clipboard after the export instead of erasing it all. Tried storing other things like images but would get some errors and it's not worth trying to get anything else working since 99% of the clipboard is text anyway.