### PR TITLE
Display win/loss for all version of deck in the left side

### DIFF
--- a/Hearthstone Deck Tracker/Controls/NewDeckPickerItem.xaml
+++ b/Hearthstone Deck Tracker/Controls/NewDeckPickerItem.xaml
@@ -44,6 +44,22 @@
                         <GradientStop Color="#FFE5E5E5" Offset="1.5" />
                     </LinearGradientBrush>
                 </DockPanel.Background>
+                
+                <Border BorderThickness="1"  BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" Width="48" DockPanel.Dock="Left" Margin="-1">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="1.618*"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <TextBlock Text="{Binding TotalWinPercentString}" VerticalAlignment="Center" HorizontalAlignment="Center"  FontSize="12" FontWeight="Medium" Foreground="Black"/>
+                        <Border BorderThickness="1"  BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" Width="48" Margin="-1" Grid.Row="1" >
+                            <Viewbox Stretch="Uniform" StretchDirection="DownOnly" Margin="2,0">
+                                <TextBlock Text="{Binding TotalWinLossString}" VerticalAlignment="Center" HorizontalAlignment="Center"  FontSize="12" FontWeight="Medium" Foreground="Black"/>
+                            </Viewbox>
+                        </Border>
+                    </Grid>
+                </Border>
+                
                 <Border BorderThickness="1"  BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" Width="48" DockPanel.Dock="Right" Margin="-1">
                     <Grid>
                         <Grid.RowDefinitions>
@@ -63,7 +79,7 @@
             <Label Content="{Binding TagList}" Grid.Column="0" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="10" Margin="0,23,48,0" Foreground="Black" />
             <Ellipse Width="17" Height="17" Stroke="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" HorizontalAlignment="Right" Margin="0,4,52,0" VerticalAlignment="Top" Visibility="{Binding NoteVisibility, RelativeSource={RelativeSource AncestorType=controls:NewDeckPickerItem}}"/>
             <Label Content="N" FontWeight="Medium" HorizontalAlignment="Right" Margin="0,-1,51,0" Foreground="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" Visibility="{Binding NoteVisibility, RelativeSource={RelativeSource AncestorType=controls:NewDeckPickerItem}}" ToolTip="{Binding Note, RelativeSource={RelativeSource AncestorType=controls:NewDeckPickerItem}}"/>
-            <Image Source="../Resources/archived_marker.png" Width="16" Height="16" Margin="5,5,0,0" VerticalAlignment="Top" HorizontalAlignment="Left" Visibility="{Binding ArchivedVisibility, RelativeSource={RelativeSource AncestorType=controls:NewDeckPickerItem}}" ToolTip="Archived"/>
+            <Image Source="../Resources/archived_marker.png" Width="16" Height="16" Margin="54,4,228,0" VerticalAlignment="Top" HorizontalAlignment="Center" Visibility="{Binding ArchivedVisibility, RelativeSource={RelativeSource AncestorType=controls:NewDeckPickerItem}}" ToolTip="Archived"/>
         </Grid>
     </Border>
     

--- a/Hearthstone Deck Tracker/Hearthstone/Deck.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Deck.cs
@@ -159,29 +159,28 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 		}
 
 		[XmlIgnore]
-		public string WinLossString
+		public String WinLossString
 		{
-			get
-			{
-				var relevantGames = GetRelevantGames();
-				if(relevantGames.Count == 0)
-					return "0-0";
-				return string.Format("{0}-{1}", relevantGames.Count(g => g.Result == GameResult.Win),
-				                     relevantGames.Count(g => g.Result == GameResult.Loss));
-			}
+			get { return this.GetWinLossString(true); }
 		}
 
 		[XmlIgnore]
-		public string WinPercentString
+        public String WinPercentString
 		{
-			get
-			{
-				var relevantGames = GetRelevantGames();
-				if(relevantGames.Count == 0)
-					return "-";
-				return Math.Round(100.0 * relevantGames.Count(g => g.Result == GameResult.Win) / relevantGames.Count, 0) + "%";
-			}
+			get { return this.GetWinPercentString(true); }
 		}
+
+        [XmlIgnore]
+        public String TotalWinLossString
+        {
+            get { return this.GetWinLossString(false); }
+        }
+
+        [XmlIgnore]
+        public String TotalWinPercentString
+        {
+            get { return this.GetWinPercentString(false); }
+        }
 
 		[XmlIgnore]
 		public double WinPercent
@@ -325,7 +324,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 
 		public event PropertyChangedEventHandler PropertyChanged;
 
-		public List<GameStats> GetRelevantGames()
+		public List<GameStats> GetRelevantGames(Boolean isFilterByVersion = true)
 		{
 			var filtered = Config.Instance.DisplayedMode == GameMode.All
 				               ? DeckStats.Games
@@ -350,30 +349,35 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 						filtered = filtered.Where(g => g.StartTime > Config.Instance.CustomDisplayedTimeFrame.Value).ToList();
 					break;
 			}
-			switch(Config.Instance.DisplayedStats)
-			{
-				case DisplayedStats.All:
-					break;
-				case DisplayedStats.Latest:
-					filtered = filtered.Where(g => g.BelongsToDeckVerion(this)).ToList();
-					break;
-				case DisplayedStats.Selected:
-					filtered = filtered.Where(g => g.BelongsToDeckVerion(GetSelectedDeckVersion())).ToList();
-					break;
-				case DisplayedStats.LatestMajor:
-					filtered =
-						filtered.Where(g => VersionsIncludingSelf.Where(v => v.Major == Version.Major).Select(GetVersion).Any(g.BelongsToDeckVerion))
-						        .ToList();
-					break;
-				case DisplayedStats.SelectedMajor:
-					filtered =
-						filtered.Where(
-						               g =>
-						               VersionsIncludingSelf.Where(v => v.Major == SelectedVersion.Major).Select(GetVersion).Any(g.BelongsToDeckVerion))
-						        .ToList();
-					break;
-			}
-			return filtered;
+
+            if (isFilterByVersion)
+            {
+                switch (Config.Instance.DisplayedStats)
+                {
+                    case DisplayedStats.All:
+                        break;
+                    case DisplayedStats.Latest:
+                        filtered = filtered.Where(g => g.BelongsToDeckVerion(this)).ToList();
+                        break;
+                    case DisplayedStats.Selected:
+                        filtered = filtered.Where(g => g.BelongsToDeckVerion(GetSelectedDeckVersion())).ToList();
+                        break;
+                    case DisplayedStats.LatestMajor:
+                        filtered =
+                            filtered.Where(g => VersionsIncludingSelf.Where(v => v.Major == Version.Major).Select(GetVersion).Any(g.BelongsToDeckVerion))
+                                    .ToList();
+                        break;
+                    case DisplayedStats.SelectedMajor:
+                        filtered =
+                            filtered.Where(
+                                           g =>
+                                           VersionsIncludingSelf.Where(v => v.Major == SelectedVersion.Major).Select(GetVersion).Any(g.BelongsToDeckVerion))
+                                    .ToList();
+                        break;
+                }
+            }
+
+            return filtered;
 		}
 
 		public void ResetHearthstatsIds()
@@ -599,5 +603,34 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 		{
 			LastEdited = DateTime.Now;
 		}
+
+        private String GetWinPercentString(Boolean isFilterByVersion)
+        {
+            var relevantGames = this.GetRelevantGames(isFilterByVersion);
+
+            if (relevantGames.Count == 0)
+            {
+                return "-";
+            }
+
+            Int32 wins = relevantGames.Count(g => g.Result == GameResult.Win);
+
+            return String.Concat(Math.Round(100.0 * wins / relevantGames.Count, 0), "%");
+        }
+
+        private String GetWinLossString(Boolean isFilterByVersion)
+        {
+            var relevantGames = this.GetRelevantGames(isFilterByVersion);
+
+            if (relevantGames.Count == 0)
+            {
+                return "0-0";
+            }
+
+            Int32 wins = relevantGames.Count(g => g.Result == GameResult.Win);
+            Int32 looses = relevantGames.Count(g => g.Result == GameResult.Loss);
+
+            return String.Format("{0}-{1}", wins, looses);
+        }
 	}
 }


### PR DESCRIPTION
Usually changes between versions of a deck are small and option to see win/loss for all versions the deck near win/loss for current version seems is nice.
![hs_total_stats](https://cloud.githubusercontent.com/assets/946095/7593961/4361442e-f8e6-11e4-98cc-7d96996a690d.png)
