### PR TITLE
Minor GUI enchancement-Changed the look of decks in deck list

### DIFF
--- a/Hearthstone Deck Tracker/Controls/DeckPicker.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/DeckPicker.xaml.cs
@@ -370,39 +370,72 @@ namespace Hearthstone_Deck_Tracker
 			}
 
 			// ReSharper disable PossibleNullReferenceException
-			public Color ClassColor
-			{
-				get
-				{
-					switch(Name)
-					{
-						case "Druid":
-							return (Color)ColorConverter.ConvertFromString("#FF7D0A");
-						case "Death Knight":
-							return (Color)ColorConverter.ConvertFromString("#C41F3B");
-						case "Hunter":
-							return (Color)ColorConverter.ConvertFromString("#ABD473");
-						case "Mage":
-							return (Color)ColorConverter.ConvertFromString("#69CCF0");
-						case "Monk":
-							return (Color)ColorConverter.ConvertFromString("#00FF96");
-						case "Paladin":
-							return (Color)ColorConverter.ConvertFromString("#F58CBA");
-						case "Priest":
-							return (Color)ColorConverter.ConvertFromString("#FFFFFF");
-						case "Rogue":
-							return (Color)ColorConverter.ConvertFromString("#FFF569");
-						case "Shaman":
-							return (Color)ColorConverter.ConvertFromString("#0070DE");
-						case "Warlock":
-							return (Color)ColorConverter.ConvertFromString("#9482C9");
-						case "Warrior":
-							return (Color)ColorConverter.ConvertFromString("#C79C6E");
-						default:
-							return Colors.Gray;
-					}
-				}
-			}
+            public Color ClassColor
+            {
+                get
+                {
+                    switch (Name)
+                    {
+                        case "Druid":
+                            return (Color)ColorConverter.ConvertFromString("#CCFF7D0A");
+                        case "Death Knight":
+                            return (Color)ColorConverter.ConvertFromString("#CCC41F3B");
+                        case "Hunter":
+                            return (Color)ColorConverter.ConvertFromString("#CCABD473");
+                        case "Mage":
+                            return (Color)ColorConverter.ConvertFromString("#CC69CCF0");
+                        case "Monk":
+                            return (Color)ColorConverter.ConvertFromString("#CC00FF96");
+                        case "Paladin":
+                            return (Color)ColorConverter.ConvertFromString("#CCF58CBA");
+                        case "Priest":
+                            return (Color)ColorConverter.ConvertFromString("#CCFFFFFF");
+                        case "Rogue":
+                            return (Color)ColorConverter.ConvertFromString("#CCFFF569");
+                        case "Shaman":
+                            return (Color)ColorConverter.ConvertFromString("#CC0070DE");
+                        case "Warlock":
+                            return (Color)ColorConverter.ConvertFromString("#CC9482C9");
+                        case "Warrior":
+                            return (Color)ColorConverter.ConvertFromString("#CCC79C6E");
+                        default:
+                            return Colors.Gray;
+                    }
+                }
+            }
+            public Color ClassDarkColor
+            {
+                get
+                {
+                    switch (Name)
+                    {
+                        case "Druid":
+                            return (Color)ColorConverter.ConvertFromString("#CC3F2712");
+                        case "Death Knight":
+                            return (Color)ColorConverter.ConvertFromString("#CC450E17");
+                        case "Hunter":
+                            return (Color)ColorConverter.ConvertFromString("#CC1E2910");
+                        case "Mage":
+                            return (Color)ColorConverter.ConvertFromString("#CC19404E");
+                        case "Monk":
+                            return (Color)ColorConverter.ConvertFromString("#CC0A4C31");
+                        case "Paladin":
+                            return (Color)ColorConverter.ConvertFromString("#CC311C25");
+                        case "Priest":
+                            return (Color)ColorConverter.ConvertFromString("#CC5C5A5B");
+                        case "Rogue":
+                            return (Color)ColorConverter.ConvertFromString("#CC5A5726");
+                        case "Shaman":
+                            return (Color)ColorConverter.ConvertFromString("#CC012B55");
+                        case "Warlock":
+                            return (Color)ColorConverter.ConvertFromString("#CC332D45");
+                        case "Warrior":
+                            return (Color)ColorConverter.ConvertFromString("#CC4D3822");
+                        default:
+                            return Colors.Gray;
+                    }
+                }
+            }
 
 			// ReSharper restore PossibleNullReferenceException
 			public FontWeight GetFontWeight

--- a/Hearthstone Deck Tracker/Controls/DeckPickerItem.xaml
+++ b/Hearthstone Deck Tracker/Controls/DeckPickerItem.xaml
@@ -10,8 +10,11 @@
           >
         <Grid.Background>
             <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
-                <GradientStop Color="{Binding ClassColor}" Offset="0" />
-                <GradientStop Color="#FFE5E5E5" Offset="1" />
+                <GradientStop Color="{Binding ClassColor}" Offset="0.01" />
+                <GradientStop Color="{Binding ClassDarkColor}" Offset="0.1" />
+                <GradientStop Color="{Binding ClassDarkColor}" Offset="0.105" />
+                <GradientStop Color="{Binding ClassColor}" Offset="0.5" />
+                <GradientStop Color="{Binding ClassColor}" Offset="1" />
             </LinearGradientBrush>
         </Grid.Background>
         <Grid.ColumnDefinitions>

--- a/Hearthstone Deck Tracker/Controls/NewDeckPickerItem.xaml
+++ b/Hearthstone Deck Tracker/Controls/NewDeckPickerItem.xaml
@@ -1,11 +1,12 @@
-﻿<UserControl x:Class="Hearthstone_Deck_Tracker.Controls.NewDeckPickerItem"
+﻿<UserControl x:Name="UsrCtrl" x:Class="Hearthstone_Deck_Tracker.Controls.NewDeckPickerItem"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:controls="clr-namespace:Hearthstone_Deck_Tracker.Controls"
              mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300" Height="48">
+             d:DesignHeight="300" d:DesignWidth="300" Height="48"
+             Opacity="0.5">
     <UserControl.ContextMenu>
         <ContextMenu Opened="ContextMenu_OnOpened">
             <MenuItem Header="EDIT _DECK" Click="BtnEditDeck_Click" />
@@ -40,8 +41,11 @@
             <DockPanel>
                 <DockPanel.Background>
                     <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
-                        <GradientStop Color="{Binding ClassColor}" Offset="-0.5" />
-                        <GradientStop Color="#FFE5E5E5" Offset="1.5" />
+                        <GradientStop Color="{Binding ClassColor}" Offset="0.01" />
+                        <GradientStop Color="{Binding ClassDarkColor}" Offset="0.1" />
+                        <GradientStop Color="{Binding ClassDarkColor}" Offset="0.105" />
+                        <GradientStop Color="{Binding ClassColor}" Offset="0.5" />
+                        <GradientStop Color="{Binding ClassColor}" Offset="1" />
                     </LinearGradientBrush>
                 </DockPanel.Background>
                 <Border BorderThickness="1"  BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" Width="48" DockPanel.Dock="Right" Margin="-1">

--- a/Hearthstone Deck Tracker/Controls/NewDeckPickerItem.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/NewDeckPickerItem.xaml.cs
@@ -41,13 +41,15 @@ namespace Hearthstone_Deck_Tracker.Controls
 		{
 			//BorderItem.Height = Big;
 			SelectedFontWeight = FontWeights.Bold;
+            UsrCtrl.Opacity = 1;
 			OnPropertyChanged("SelectedFontWeight");
 		}
 
 		public void OnDelselected()
 		{
 			//BorderItem.Height = Small;
-			SelectedFontWeight = FontWeights.Regular;
+            SelectedFontWeight = FontWeights.Regular;
+            UsrCtrl.Opacity = 0.5;
 			OnPropertyChanged("SelectedFontWeight");
 		}
 

--- a/Hearthstone Deck Tracker/Hearthstone/Deck.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Deck.cs
@@ -247,40 +247,75 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			get { return new SolidColorBrush(ClassColor); }
 		}
 
-		[XmlIgnore]
-		public Color ClassColor
-		{
-			get
-			{
-				switch(Class)
-				{
-					case "Druid":
-						return (Color)ColorConverter.ConvertFromString("#FF7D0A");
-					case "Death Knight":
-						return (Color)ColorConverter.ConvertFromString("#C41F3B");
-					case "Hunter":
-						return (Color)ColorConverter.ConvertFromString("#ABD473");
-					case "Mage":
-						return (Color)ColorConverter.ConvertFromString("#69CCF0");
-					case "Monk":
-						return (Color)ColorConverter.ConvertFromString("#00FF96");
-					case "Paladin":
-						return (Color)ColorConverter.ConvertFromString("#F58CBA");
-					case "Priest":
-						return (Color)ColorConverter.ConvertFromString("#FFFFFF");
-					case "Rogue":
-						return (Color)ColorConverter.ConvertFromString("#FFF569");
-					case "Shaman":
-						return (Color)ColorConverter.ConvertFromString("#0070DE");
-					case "Warlock":
-						return (Color)ColorConverter.ConvertFromString("#9482C9");
-					case "Warrior":
-						return (Color)ColorConverter.ConvertFromString("#C79C6E");
-					default:
-						return Colors.Gray;
-				}
-			}
-		}
+
+        [XmlIgnore]
+        public Color ClassColor
+        {
+            get
+            {
+                switch (Class)
+                {
+                    case "Druid":
+                        return (Color)ColorConverter.ConvertFromString("#CCFF7D0A");
+                    case "Death Knight":
+                        return (Color)ColorConverter.ConvertFromString("#CCC41F3B");
+                    case "Hunter":
+                        return (Color)ColorConverter.ConvertFromString("#CCABD473");
+                    case "Mage":
+                        return (Color)ColorConverter.ConvertFromString("#CC69CCF0");
+                    case "Monk":
+                        return (Color)ColorConverter.ConvertFromString("#CC00FF96");
+                    case "Paladin":
+                        return (Color)ColorConverter.ConvertFromString("#CCF58CBA");
+                    case "Priest":
+                        return (Color)ColorConverter.ConvertFromString("#CCFFFFFF");
+                    case "Rogue":
+                        return (Color)ColorConverter.ConvertFromString("#CCFFF569");
+                    case "Shaman":
+                        return (Color)ColorConverter.ConvertFromString("#CC0070DE");
+                    case "Warlock":
+                        return (Color)ColorConverter.ConvertFromString("#CC9482C9");
+                    case "Warrior":
+                        return (Color)ColorConverter.ConvertFromString("#CCC79C6E");
+                    default:
+                        return Colors.Gray;
+                }
+            }
+        }
+        [XmlIgnore]
+        public Color ClassDarkColor
+        {
+            get
+            {
+                switch (Class)
+                {
+                    case "Druid":
+                        return (Color)ColorConverter.ConvertFromString("#CC3F2712");
+                    case "Death Knight":
+                        return (Color)ColorConverter.ConvertFromString("#CC450E17");
+                    case "Hunter":
+                        return (Color)ColorConverter.ConvertFromString("#CC1E2910");
+                    case "Mage":
+                        return (Color)ColorConverter.ConvertFromString("#CC19404E");
+                    case "Monk":
+                        return (Color)ColorConverter.ConvertFromString("#CC0A4C31");
+                    case "Paladin":
+                        return (Color)ColorConverter.ConvertFromString("#CC311C25");
+                    case "Priest":
+                        return (Color)ColorConverter.ConvertFromString("#CC5C5A5B");
+                    case "Rogue":
+                        return (Color)ColorConverter.ConvertFromString("#CC5A5726");
+                    case "Shaman":
+                        return (Color)ColorConverter.ConvertFromString("#CC012B55");
+                    case "Warlock":
+                        return (Color)ColorConverter.ConvertFromString("#CC332D45");
+                    case "Warrior":
+                        return (Color)ColorConverter.ConvertFromString("#CC4D3822");
+                    default:
+                        return Colors.Gray;
+                }
+            }
+        }
 
 		[XmlIgnore]
 		public BitmapImage HeroImage


### PR DESCRIPTION
This update is inspired by #473 :)

I've made some changes to the list of created decks:
+ As you can see, there is much more easier now to notice currently chosen deck(opacity of unchecked decks is set to 60%).
+ The background gradient of each deck has been changed - in my opinion it looks now way better and modern than the previous gradient (but it's only my opinion ;) ).

![image](https://cloud.githubusercontent.com/assets/11271981/7720936/0eef3d3e-fed3-11e4-89ae-0763a08a76c3.png)
