### PR TITLE
Allow Plugins to save decks in HDT

### DIFF
--- a/Hearthstone Deck Tracker/MainWindow/MainWindow_NewDeck.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow_NewDeck.cs
@@ -112,7 +112,7 @@ namespace Hearthstone_Deck_Tracker
 			}
 		}
 
-		private async void SaveDeck(bool overwrite, SerializableVersion newVersion)
+		public async void SaveDeck(bool overwrite, SerializableVersion newVersion, bool workInProgressDeck = false)
 		{
 			var deckName = TextBoxDeckName.Text;
 
@@ -129,7 +129,7 @@ namespace Hearthstone_Deck_Tracker
 				TextBoxDeckName.Text = name;
 			}
 
-			if(_newDeck.Cards.Sum(c => c.Count) != 30)
+			if(_newDeck.Cards.Sum(c => c.Count) != 30 && workInProgressDeck == false)
 			{
 				var settings = new MetroDialogSettings {AffirmativeButtonText = "Yes", NegativeButtonText = "No"};
 


### PR DESCRIPTION
I'd like to be able to Set and Save a deck from within a plugin. Currently SaveDeck is private.

Also I'd like to be able to not show the "the deck doesn't contain 30 cards" confirmation as this will break automation.

This is is allow the following feature in a plugin:

https://github.com/rembound/Arena-Helper/issues/11

Let me know your thoughts.