### PR TITLE
Fix export to hearthstone collection filters after latest patch

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -133,17 +133,23 @@ namespace Hearthstone_Deck_Tracker
 		[DefaultValue(true)]
 		public bool EnterToSaveNote = true;
 
+		[DefaultValue(0.06)]
+		public double ExportAllButtonX = 0.06;
+
+		[DefaultValue(0.915)]
+		public double ExportAllButtonY = 0.915;
+
 		[DefaultValue(0.118)]
-		public double ExportAllButtonX = 0.118;
+		public double ExportZeroButtonX = 0.118;
 
 		[DefaultValue(0.917)]
-		public double ExportAllButtonY = 0.917;
+		public double ExportZeroButtonY = 0.917;
 
 		[DefaultValue(0.108)]
-		public double ExportAllSquareX = 0.108;
+		public double ExportZeroSquareX = 0.108;
 
 		[DefaultValue(0.907)]
-		public double ExportAllSquareY = 0.907;
+		public double ExportZeroSquareY = 0.907;
 
 		[DefaultValue(0.049)]
 		public double ExportSetsButtonX = 0.049;

--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -133,11 +133,29 @@ namespace Hearthstone_Deck_Tracker
 		[DefaultValue(true)]
 		public bool EnterToSaveNote = true;
 
-		[DefaultValue(0.06)]
-		public double ExportAllButtonX = 0.06;
+		[DefaultValue(0.118)]
+		public double ExportAllButtonX = 0.118;
 
-		[DefaultValue(0.915)]
-		public double ExportAllButtonY = 0.915;
+		[DefaultValue(0.917)]
+		public double ExportAllButtonY = 0.917;
+
+		[DefaultValue(0.108)]
+		public double ExportAllSquareX = 0.108;
+
+		[DefaultValue(0.907)]
+		public double ExportAllSquareY = 0.907;
+
+		[DefaultValue(0.049)]
+		public double ExportSetsButtonX = 0.049;
+
+		[DefaultValue(0.917)]
+		public double ExportSetsButtonY = 0.917;
+
+		[DefaultValue(0.067)]
+		public double ExportAllSetsButtonX = 0.067;
+
+		[DefaultValue(0.639)]
+		public double ExportAllSetsButtonY = 0.639;
 
 		[DefaultValue(0.04)]
 		public double ExportCard1X = 0.04;

--- a/Hearthstone Deck Tracker/DeckExporter.cs
+++ b/Hearthstone Deck Tracker/DeckExporter.cs
@@ -112,10 +112,60 @@ namespace Hearthstone_Deck_Tracker
 		private static async Task ClickAllCrystal(double ratio, int width, int height, IntPtr hsHandle)
 		{
 			Logger.WriteLine("Clicking \"all\" crystal...", "DeckExporter");
-			await
-				ClickOnPoint(hsHandle,
-				             new Point((int)GetXPos(Config.Instance.ExportAllButtonX, width, ratio),
-				                       (int)(Config.Instance.ExportAllButtonY * height)));
+
+			// First, ensure mana filters are cleared
+
+			var crystalPoint = new Point((int)GetXPos(Config.Instance.ExportAllButtonX, width, ratio),
+				(int)(Config.Instance.ExportAllButtonY * height));
+
+			if (IsZeroCrystalSelected(hsHandle, ratio, width, height))
+			{
+				// deselect it
+				await ClickOnKnownPoint(hsHandle, crystalPoint);
+			}
+			else
+			{
+				// select it and then unselect it (in case other crystals are on)
+				await ClickOnKnownPoint(hsHandle, crystalPoint);
+				await ClickOnKnownPoint(hsHandle, crystalPoint);
+			}
+
+			// Then ensure "All Sets" is selected
+
+			var setsPoint = new Point((int)GetXPos(Config.Instance.ExportSetsButtonX, width, ratio),
+				(int)(Config.Instance.ExportSetsButtonY * height));
+
+			// open sets menu
+			await ClickOnKnownPoint(hsHandle, setsPoint);
+			// select "All Sets"
+			await ClickOnPoint(hsHandle,
+				new Point((int)GetXPos(Config.Instance.ExportAllSetsButtonX, width, ratio), 
+					(int)(Config.Instance.ExportAllSetsButtonY * height)));
+			// close sets menu
+			await ClickOnKnownPoint(hsHandle, setsPoint);
+		}
+
+		// checks the zero crystal, to see if it is selected
+		private static bool IsZeroCrystalSelected(IntPtr wndHandle, double ratio, int width, int height)
+		{
+			const int cWidth = 22;
+			const int cHeight = 22;
+			const double minBrightness = 0.55;
+
+			int posX = (int)GetXPos(Config.Instance.ExportAllSquareX, width, ratio);
+			int posY = (int)(Config.Instance.ExportAllSquareY * height);
+
+			var capture = Helper.CaptureHearthstone(new Point(posX, posY), cWidth, cHeight, wndHandle);
+
+			if(capture == null)
+				return false;
+
+			return GetAverageHueAndBrightness(capture).Brightness > minBrightness;
+		}
+
+		private static async Task ClickOnKnownPoint(IntPtr wndHandle, Point p)
+		{
+			await ClickOnPoint(wndHandle, p);
 		}
 
 		private static async Task SetDeckName(string name, double ratio, int width, int height, IntPtr hsHandle)

--- a/Hearthstone Deck Tracker/DeckExporter.cs
+++ b/Hearthstone Deck Tracker/DeckExporter.cs
@@ -111,12 +111,17 @@ namespace Hearthstone_Deck_Tracker
 
 		private static async Task ClickAllCrystal(double ratio, int width, int height, IntPtr hsHandle)
 		{
-			Logger.WriteLine("Clicking \"all\" crystal...", "DeckExporter");
+			await ClearZeroCrystal(ratio, width, height, hsHandle);
+		}
+
+		private static async Task ClearZeroCrystal(double ratio, int width, int height, IntPtr hsHandle)
+		{
+			Logger.WriteLine("Clearing \"Zero\" crystal...", "DeckExporter");
 
 			// First, ensure mana filters are cleared
 
-			var crystalPoint = new Point((int)GetXPos(Config.Instance.ExportAllButtonX, width, ratio),
-				(int)(Config.Instance.ExportAllButtonY * height));
+			var crystalPoint = new Point((int)GetXPos(Config.Instance.ExportZeroButtonX, width, ratio),
+				(int)(Config.Instance.ExportZeroButtonY * height));
 
 			if (IsZeroCrystalSelected(hsHandle, ratio, width, height))
 			{
@@ -152,8 +157,8 @@ namespace Hearthstone_Deck_Tracker
 			const int cHeight = 22;
 			const double minBrightness = 0.55;
 
-			int posX = (int)GetXPos(Config.Instance.ExportAllSquareX, width, ratio);
-			int posY = (int)(Config.Instance.ExportAllSquareY * height);
+			int posX = (int)GetXPos(Config.Instance.ExportZeroSquareX, width, ratio);
+			int posY = (int)(Config.Instance.ExportZeroSquareY * height);
 
 			var capture = Helper.CaptureHearthstone(new Point(posX, posY), cWidth, cHeight, wndHandle);
 


### PR DESCRIPTION
With the new collection manager layout, the mana and sets filters are different. The mana filters now toggle on and off and the sets filter has moved. This is also the cause of a problem when exporting decks #1106 #1091.

Changed the `DeckExporter.ClickAllCrystal` to work with the new layout and added support to always change the set to *All Sets*.

I added some new values to `Config.cs`, I'm not sure how this works with the user's current config file - does something need to be added to change their local values?