### PR TITLE
Fixed login issue "Crash on incorrect password" (#1120)

### DIFF
--- a/Hearthstone Deck Tracker/LoginWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/LoginWindow.xaml.cs
@@ -109,8 +109,14 @@ namespace Hearthstone_Deck_Tracker
 			TextBlockErrorMessage.Text = error;
 			TextBlockErrorMessage.Visibility = Visibility.Visible;
 			IsEnabled = true;
-			if(_controller != null)
-				await _controller.CloseAsync();
+            if (_controller != null)
+            {
+                if (_controller.IsOpen)
+                {
+                    await _controller.CloseAsync();
+                }
+            }
+				
 		}
 
 		private void CheckBoxRememberLogin_Checked(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Added a check to make sure _controller was opened before we attempt to close since there are some validations that are not handled by a third party.