### PR TITLE
fix hero detection regex

### DIFF
--- a/Hearthstone Deck Tracker/Hearthstone/Game.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Game.cs
@@ -843,7 +843,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 		public static string GetHeroNameFromId(string id, bool returnIdIfNotFound = true)
 		{
 			string name;
-			var match = Regex.Match(id, @"(?<base>(.*_\d+)).+");
+			var match = Regex.Match(id, @"(?<base>(.*_\d+)).*");
 			if(match.Success)
 				id = match.Groups["base"].Value;
 			if(CardIds.HeroIdDict.TryGetValue(id, out name))


### PR DESCRIPTION
If the id parameter is e.g. "HERO_07", the regex matched HERO_0. This causes the function to detect an unknown hero and return null. Shouldn't it be * instead + in the end?