### PR TITLE
Export deck screenshots to imgur.com

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -592,6 +592,12 @@ namespace Hearthstone_Deck_Tracker
 		public bool ShowExportingDialog = true;
 
 		[DefaultValue(false)]
+		public bool DeckScreenshotToImgur = false;
+
+		[DefaultValue("7e1ab33fda207c2")]
+		public string ImgurClientId = "7e1ab33fda207c2";
+
+		[DefaultValue(false)]
 		public bool ShowInTaskbar = false;
 
 		[DefaultValue(true)]

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerExporting.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerExporting.xaml
@@ -61,6 +61,11 @@
                                               HorizontalAlignment="Left" Margin="10,5,0,0"
                                               VerticalAlignment="Top" Checked="CheckboxShowDialog_OnChecked"
                                               Unchecked="CheckboxShowDialog_OnUnchecked" />
+                    <Separator Margin="0,5,0,0"/>
+                    <CheckBox x:Name="CheckboxUploadScreenshot" Content="Upload deck screenshots to Imgur"
+                                              HorizontalAlignment="Left" Margin="10,5,0,0"
+                                              VerticalAlignment="Top" Checked="CheckboxUploadScreenshot_OnChecked"
+                                              Unchecked="CheckboxUploadScreenshot_OnUnchecked" />
 
                 </StackPanel>
             </ScrollViewer>

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerExporting.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerExporting.xaml.cs
@@ -206,5 +206,21 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			Config.Instance.ShowExportingDialog = false;
 			Config.Save();
 		}
+
+		private void CheckboxUploadScreenshot_OnChecked(object sender, RoutedEventArgs e)
+		{
+			if(!_initialized)
+				return;
+			Config.Instance.DeckScreenshotToImgur = true;
+			Config.Save();
+		}
+
+		private void CheckboxUploadScreenshot_OnUnchecked(object sender, RoutedEventArgs e)
+		{
+			if(!_initialized)
+				return;
+			Config.Instance.DeckScreenshotToImgur = false;
+			Config.Save();
+		}
 	}
 }

--- a/Hearthstone Deck Tracker/Hearthstone Deck Tracker.csproj
+++ b/Hearthstone Deck Tracker/Hearthstone Deck Tracker.csproj
@@ -235,6 +235,7 @@
     <Compile Include="Utility\BackupManager.cs" />
     <Compile Include="Protocol\PipeServer.cs" />
     <Compile Include="Utility\ImageCache.cs" />
+    <Compile Include="Utility\Imgur.cs" />
     <Compile Include="Windows\AddGameDialog.xaml.cs">
       <DependentUpon>AddGameDialog.xaml</DependentUpon>
     </Compile>

--- a/Hearthstone Deck Tracker/MainWindow/MainWindow_Export.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow_Export.cs
@@ -87,10 +87,25 @@ namespace Hearthstone_Deck_Tracker
 
 				if(fileName != null)
 				{
-					using(var stream = new FileStream(fileName, FileMode.Create, FileAccess.Write))
-						pngEncoder.Save(stream);
+					string imgurUrl = null;
+					using(var ms = new MemoryStream())
+					using(var fs = new FileStream(fileName, FileMode.Create, FileAccess.Write))
+					{
+						pngEncoder.Save(ms);
+						ms.CopyTo(fs);
+						if (Config.Instance.DeckScreenshotToImgur)
+							imgurUrl = await Imgur.Upload(Config.Instance.ImgurClientId, ms, deck.Name);
+					}
 
-					await this.ShowSavedFileMessage(fileName);
+					if(imgurUrl != null)
+					{
+						await this.ShowSavedAndUploadedFileMessage(fileName, imgurUrl);
+						Logger.WriteLine("Uploaded screenshot to " + imgurUrl, "Export");
+					}
+					else
+					{
+						await this.ShowSavedFileMessage(fileName);
+					}
 					Logger.WriteLine("Saved screenshot of " + deck.GetDeckInfo() + " to file: " + fileName, "Export");
 				}
 			}

--- a/Hearthstone Deck Tracker/MainWindow/MainWindow_Export.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow_Export.cs
@@ -77,7 +77,7 @@ namespace Hearthstone_Deck_Tracker
 			var dpiX = 96.0 * source.CompositionTarget.TransformToDevice.M11;
 			var dpiY = 96.0 * source.CompositionTarget.TransformToDevice.M22;
 
-			var deck = DeckList.Instance.ActiveDeckVersion;
+			var deck = selectedDeck.GetSelectedDeckVersion();
 			var pngEncoder = Helper.ScreenshotDeck(screenShotWindow.ListViewPlayer, dpiX, dpiY, deck.Name);
 			screenShotWindow.Shutdown();
 

--- a/Hearthstone Deck Tracker/Utility/Imgur.cs
+++ b/Hearthstone Deck Tracker/Utility/Imgur.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Hearthstone_Deck_Tracker
+{
+	public static class Imgur
+	{
+		public static async Task<string> Upload(string clientId, MemoryStream image, string name = null)
+		{
+			const string url = @"https://api.imgur.com/3/upload";
+
+			WebClient web = new WebClient();
+			web.Headers.Add("Authorization", "Client-ID " + clientId);
+
+			NameValueCollection Keys = new NameValueCollection();
+			try 
+			{
+				var imgBase64 = Convert.ToBase64String(image.GetBuffer());
+				Keys.Add("image", imgBase64);
+				if (name != null)
+					Keys.Add("name", name);
+
+				byte[] responseArray = await web.UploadValuesTaskAsync(url, Keys);
+
+				var reader = new StreamReader(new MemoryStream(responseArray), Encoding.Default);
+				var json = reader.ReadToEnd();
+				var resp = JsonConvert.DeserializeObject<ImgurResponse>(json);
+
+				Logger.WriteLine("Response (" + resp.status + ") " +  resp.data.link, "Imgur");
+				if (resp.success && resp.status == 200)
+				{
+					return resp.data.link;
+				}
+				else
+				{
+					throw new Exception("response code " + resp.status);
+				}
+			}
+			catch (Exception s) 
+			{ 
+				Logger.WriteLine("Upload to imgur failed: " + s.Message); 
+			}
+			return null;
+		}
+
+		private class ImgurResponse
+		{
+			public ImgurDataImage data { get; set; }
+			public bool success { get; set; }
+			public int status { get; set; }
+
+			public class ImgurDataImage
+			{
+				public string id { get; set; }
+				public string title { get; set; }
+				public string name { get; set; }
+				public string deletehash { get; set; }
+				public string link { get; set; }
+			}
+		}
+
+	}
+}

--- a/Hearthstone Deck Tracker/Windows/MessageDialogs.cs
+++ b/Hearthstone Deck Tracker/Windows/MessageDialogs.cs
@@ -60,6 +60,15 @@ namespace Hearthstone_Deck_Tracker.Windows
 				Process.Start(Path.GetDirectoryName(fileName));
 		}
 
+		public static async Task ShowSavedAndUploadedFileMessage(this MainWindow window, string fileName, string url)
+		{
+			var settings = new MetroDialogSettings { NegativeButtonText = "Open Link" };
+			var result =
+				await window.ShowMessageAsync("", "Saved to\n\"" + fileName + "\"\nUploaded to\n" + url, MessageDialogStyle.AffirmativeAndNegative, settings);
+			if(result == MessageDialogResult.Negative)
+				Process.Start(url);
+		}
+
 		public static async Task ShowHsNotInstalledMessage(this MetroWindow window)
 		{
 			var settings = new MetroDialogSettings {AffirmativeButtonText = "Ok", NegativeButtonText = "Select manually"};


### PR DESCRIPTION
Added an option under `Tracker > Exporting` to allow deck screenshots to be uploaded to imgur.com. Consists of new `Imgur.cs` class for uploading. Addition of config values for API key and enabling the feature. Changes to `MainWindow_Export.cs` and `MessageDialogs.cs` to cater for uploading.

Also, fixed small issue with screenshot file name being incorrect when selected deck is not active. It turns out this will also fix a crash when no deck is active and screenshot is pressed #1152.

@Epix37 I added the API key I used when testing `public string ImgurClientId = "7e1ab33fda207c2"` to `Config.cs`. If you add it to a release you will probably want to register your own anonymous key for HDT at [imgur](https://api.imgur.com/oauth2/addclient) - takes like two minutes.