### PR TITLE
Various Brawl related fixes

### DIFF
--- a/HDTTests/HDTTests.csproj
+++ b/HDTTests/HDTTests.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <Compile Include="HearthStats\ApiTest.cs" />
     <Compile Include="Hearthstone\DeckTest.cs" />
+    <Compile Include="Hearthstone\CardDbTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/HDTTests/Hearthstone/CardDbTest.cs
+++ b/HDTTests/Hearthstone/CardDbTest.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Hearthstone_Deck_Tracker.Hearthstone;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HDTTests.Hearthstone
+{
+	[TestClass]
+	public class CardDBTest
+	{
+		/*
+		 *  Correct for patch 2.7.0.9166
+		 */
+
+		[TestMethod]
+		public void TestTotalCollectableCards()
+		{
+			Assert.AreEqual(566, Game.GetActualCards().Count);
+		}
+
+		[TestMethod]
+		public void TestHeroSkins()
+		{
+			var Alleria = Game.GetHeroNameFromId("HERO_05a");
+			Assert.AreEqual("Hunter", Alleria);
+
+			var AlleriaPower = Game.GetCardFromId("DS1h_292_H1");
+			Assert.AreEqual("Steady Shot", AlleriaPower.Name);
+		}
+
+		[TestMethod]
+		public void TestBrawlCards()
+		{
+			var Rotten = Game.GetCardFromId("TB_008");
+			Assert.AreEqual("Rotten Banana", Rotten.Name);
+
+			var Moira = Game.GetCardFromId("BRMC_87");
+			Assert.AreEqual("Moira Bronzebeard", Moira.Name);
+		}
+	}
+}

--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -455,6 +455,9 @@ namespace Hearthstone_Deck_Tracker
 		public bool RecordOther = false;
 
 		[DefaultValue(false)]
+		public bool RecordBrawl = false;
+
+		[DefaultValue(false)]
 		public bool RecordPractice = false;
 
 		[DefaultValue(true)]

--- a/Hearthstone Deck Tracker/DeckExporter.cs
+++ b/Hearthstone Deck Tracker/DeckExporter.cs
@@ -61,7 +61,7 @@ namespace Hearthstone_Deck_Tracker
 				if(Config.Instance.AutoClearDeck)
 					await ClearDeck(hsRect.Width, hsRect.Height, hsHandle, ratio);
 
-				if(Config.Instance.ExportSetDeckName)
+				if(Config.Instance.ExportSetDeckName && !deck.TagList.ToLower().Contains("brawl"))
 					await SetDeckName(deck.Name, ratio, hsRect.Width, hsRect.Height, hsHandle);
 
 				await ClickAllCrystal(ratio, hsRect.Width, hsRect.Height, hsHandle);

--- a/Hearthstone Deck Tracker/Enums/GameMode.cs
+++ b/Hearthstone Deck Tracker/Enums/GameMode.cs
@@ -6,6 +6,7 @@ namespace Hearthstone_Deck_Tracker.Enums
 		Ranked,
 		Casual,
 		Arena,
+		Brawl,
 		Friendly,
 		Practice,
 		Spectator,

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerStats.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerStats.xaml
@@ -23,6 +23,10 @@
                                               HorizontalAlignment="Left" Margin="0,5,0,0"
                                               VerticalAlignment="Top" Checked="CheckboxRecordArena_Checked"
                                               Unchecked="CheckboxRecordArena_Unchecked" />
+                            <CheckBox x:Name="CheckboxRecordBrawl" Content="Brawl"
+                                              HorizontalAlignment="Left" Margin="0,5,0,0"
+                                              VerticalAlignment="Top" Checked="CheckboxRecordBrawl_Checked"
+                                              Unchecked="CheckboxRecordBrawl_Unchecked" />
                             <CheckBox x:Name="CheckboxRecordCasual" Content="Casual"
                                               HorizontalAlignment="Left" Margin="0,5,0,0"
                                               VerticalAlignment="Top" Checked="CheckboxRecordCasual_Checked"

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerStats.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerStats.xaml.cs
@@ -24,6 +24,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 		public void Load()
 		{
 			CheckboxRecordArena.IsChecked = Config.Instance.RecordArena;
+			CheckboxRecordBrawl.IsChecked = Config.Instance.RecordBrawl;
 			CheckboxRecordCasual.IsChecked = Config.Instance.RecordCasual;
 			CheckboxRecordFriendly.IsChecked = Config.Instance.RecordFriendly;
 			CheckboxRecordOther.IsChecked = Config.Instance.RecordOther;
@@ -79,6 +80,22 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			if(!_initialized)
 				return;
 			Config.Instance.RecordArena = false;
+			Config.Save();
+		}
+
+		private void CheckboxRecordBrawl_Checked(object sender, RoutedEventArgs e)
+		{
+			if(!_initialized)
+				return;
+			Config.Instance.RecordBrawl = true;
+			Config.Save();
+		}
+
+		private void CheckboxRecordBrawl_Unchecked(object sender, RoutedEventArgs e)
+		{
+			if(!_initialized)
+				return;
+			Config.Instance.RecordBrawl = false;
 			Config.Save();
 		}
 

--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -39,6 +39,7 @@ namespace Hearthstone_Deck_Tracker
 				return Game.CurrentGameMode == GameMode.None && Config.Instance.RecordOther
 				       || Game.CurrentGameMode == GameMode.Practice && Config.Instance.RecordPractice
 				       || Game.CurrentGameMode == GameMode.Arena && Config.Instance.RecordArena
+				       || Game.CurrentGameMode == GameMode.Brawl && Config.Instance.RecordBrawl
 				       || Game.CurrentGameMode == GameMode.Ranked && Config.Instance.RecordRanked
 				       || Game.CurrentGameMode == GameMode.Friendly && Config.Instance.RecordFriendly
 				       || Game.CurrentGameMode == GameMode.Casual && Config.Instance.RecordCasual
@@ -384,6 +385,8 @@ namespace Hearthstone_Deck_Tracker
 					await GameModeSaved(15);
 					if(Game.CurrentGameMode == GameMode.Arena)
 						HearthStatsManager.UploadArenaMatchAsync(_lastGame, selectedDeck, background: true);
+					if(Game.CurrentGameMode == GameMode.Brawl)
+						{ /* do nothing */ }
 					else
 						HearthStatsManager.UploadMatchAsync(_lastGame, selectedDeck, background: true);
 				}

--- a/Hearthstone Deck Tracker/Hearthstone/CardIds.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/CardIds.cs
@@ -32,7 +32,10 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			"NAX",
 			"FP1_006",
 			"PART",
-			"BRMA"
+			"BRMA",
+			"BRMC",
+			"TBA",
+			"TB_"
 		};
 
 		public static readonly List<string> SecretIdsHunter = new List<string>

--- a/Hearthstone Deck Tracker/Hearthstone/Game.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Game.cs
@@ -240,15 +240,12 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 
 		public static OpponentSecrets OpponentSecrets { get; set; }
 
-		private static readonly List<string> ValidCardSets = new List<string>
+		private static readonly List<string> InValidCardSets = new List<string>
 		{
-			"Basic",
-			"Reward",
-			"Classic",
-			"Promotion",
-			"Curse of Naxxramas",
-			"Goblins vs Gnomes",
-			"Blackrock Mountain"
+			"Credits",
+			"Missions",
+			"Debug",
+			"System"
 		};
 
 		public static List<Card> DrawnLastGame { get; set; }
@@ -784,7 +781,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			try
 			{
 				var db = XmlManager<CardDb>.Load(string.Format("Files/cardDB.{0}.xml", "enUS"));
-				_cardDb = db.Cards.Where(x => ValidCardSets.Any(set => x.CardSet == set)).ToDictionary(x => x.CardId, x => x.ToCard());
+				_cardDb = db.Cards.Where(x => InValidCardSets.All(set => x.CardSet != set)).ToDictionary(x => x.CardId, x => x.ToCard());
 				if(languageTag != "enUS")
 				{
 					var localized = XmlManager<CardDb>.Load(string.Format("Files/cardDB.{0}.xml", languageTag));

--- a/Hearthstone Deck Tracker/Hearthstone/Secrets/Secret.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Secrets/Secret.cs
@@ -24,7 +24,8 @@ namespace Hearthstone_Deck_Tracker
 			get
 			{
 				return (Config.Instance.AutoGrayoutSecrets
-				        && (Game.CurrentGameMode == GameMode.Casual || Game.CurrentGameMode == GameMode.Ranked
+				        && (Game.CurrentGameMode == GameMode.Casual
+				            || Game.CurrentGameMode == GameMode.Ranked || Game.CurrentGameMode == GameMode.Brawl
 				            || Game.CurrentGameMode == GameMode.Friendly || Game.CurrentGameMode == GameMode.Practice)
 				        && Game.OpponentCards.Any(x => !x.IsStolen && x.Id == CardId & x.Count >= 2)) ? 0 : Count;
 			}

--- a/Hearthstone Deck Tracker/HsLogReader.cs
+++ b/Hearthstone Deck Tracker/HsLogReader.cs
@@ -51,6 +51,7 @@ namespace Hearthstone_Deck_Tracker
 		private readonly Regex _tagChangeRegex = new Regex(@"TAG_CHANGE\ Entity=(?<entity>(.+))\ tag=(?<tag>(\w+))\ value=(?<value>(\w+))");
 		private readonly List<Entity> _tmpEntities = new List<Entity>();
 		private readonly Regex _unloadCardRegex = new Regex(@"unloading\ name=(?<id>(\w+_\w+))\ family=CardPrefab\ persistent=False");
+		private readonly Regex _unloadBrawlAsset = new Regex(@"unloading name=Tavern_Brawl\ ");
 		private readonly int _updateDelay;
 		private readonly Regex _updatingEntityRegex = new Regex(@"SHOW_ENTITY\ -\ Updating\ Entity=(?<entity>(.+))\ CardID=(?<cardId>(\w*))");
 		private int _addToTurn;
@@ -516,6 +517,10 @@ namespace Hearthstone_Deck_Tracker
 							_gameHandler.HandlePossibleArenaCard(id);
 						else
 							_gameHandler.HandlePossibleConstructedCard(id, true);
+					}
+					else if(_unloadBrawlAsset.IsMatch(logLine))
+					{
+						_gameHandler.SetGameMode(GameMode.Brawl);
 					}
 				}
 					#endregion

--- a/Hearthstone Deck Tracker/Windows/AddGameDialog.xaml
+++ b/Hearthstone Deck Tracker/Windows/AddGameDialog.xaml
@@ -37,6 +37,7 @@
                 <enums:GameMode>Ranked</enums:GameMode>
                 <enums:GameMode>Casual</enums:GameMode>
                 <enums:GameMode>Arena</enums:GameMode>
+                <enums:GameMode>Brawl</enums:GameMode>
                 <enums:GameMode>Friendly</enums:GameMode>
                 <enums:GameMode>Practice</enums:GameMode>
             </ComboBox>


### PR DESCRIPTION
1. Fixed loading of brawl cards from xml, changed from `ValidCardSets` to `InValidCardSets` so it only lists the sets to be excluded - should make future updates smoother. Also, added the invalid card ids from brawl, so `GetActualCards` is correct.
-   Added `GameMode.Brawl` and related logic. Used assets unloading to detect brawl games, seems to work well.
- Small workaround to stop "Brawl" decks from trying to change the deck name on exporting to Hearthstone. Had to use deck tags, couldn't detect the brawl deck manager. 