### PR TITLE
Fix plugin loading bug

### DIFF
--- a/Hearthstone Deck Tracker/App.config
+++ b/Hearthstone Deck Tracker/App.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+    <runtime>
+      <loadFromRemoteSources enabled="true"/>
+    </runtime>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>


### PR DESCRIPTION
https://msdn.microsoft.com/en-us/library/dd409252(VS.100).aspx

Not having this set was causing plugins to not load with the exception listed in the page linked above.  Likely others have hit this, and it doesn't seem like a terrible idea to set loadFromRemoteSources...

The exact exception fixed is:

An attempt was made to load an assembly from a network location which would have caused the assembly to be sandboxed in previous versions of the .NET Framework. This release of the .NET Framework does not enable CAS policy by default, so this load may be dangerous. If this load is not intended to sandbox the assembly, please enable the loadFromRemoteSources switch. See http://go.microsoft.com/fwlink/?LinkId=155569 for more information.

Presumably this is because I am running some version of .net > 4.0?