### PR TITLE
Add China region constant

### DIFF
--- a/Hearthstone Deck Tracker/Enums/Region.cs
+++ b/Hearthstone Deck Tracker/Enums/Region.cs
@@ -6,6 +6,7 @@ namespace Hearthstone_Deck_Tracker.Enums
 		UNKNOWN = 0,
 		US = 1,
 		EU = 2,
-		ASIA = 3
+		ASIA = 3,
+		CHINA = 5
 	}
 }


### PR DESCRIPTION
The constant 5 is used for China region. Without it we may
get an error when serializing DeckStat to disk:

  Instance validation error: '5' is not a valid value for
  Hearthstone_Deck_Tracker.Enums.Region.

This fixes #1143.