### PR TITLE
Fix Dreadscale not being added to ActualCards

### DIFF
--- a/HDTTests/Hearthstone/CardDbTest.cs
+++ b/HDTTests/Hearthstone/CardDbTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Linq;
+using System.IO;
 using Hearthstone_Deck_Tracker.Hearthstone;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -7,14 +8,33 @@ namespace HDTTests.Hearthstone
 	[TestClass]
 	public class CardDBTest
 	{
-		/*
-		 *  Correct for patch 2.7.0.9166
-		 */
-
+		// Test collectable card count
 		[TestMethod]
 		public void TestTotalCollectableCards()
 		{
-			Assert.AreEqual(566, Game.GetActualCards().Count);
+			// 3.0.0.9786 - TGT
+			Assert.AreEqual(698, Game.GetActualCards().Count);
+		}
+
+		// Dreadscale card has unusual id ending in 't', some tests to check it is recognized
+		[TestMethod]
+		public void TestDreadscaleFromId()
+		{
+			var card = Game.GetCardFromId("AT_063t");
+			Assert.AreEqual("Dreadscale", card.Name);
+		}
+		[TestMethod]
+		public void TestDreadscaleInGetActual()
+		{
+			var db = Game.GetActualCards();
+			var found = db.Any<Card>(c => c.LocalizedName.ToLowerInvariant().Contains("dreadscale"));
+			Assert.IsTrue(found);
+		}
+		[TestMethod]
+		public void TestDreadscaleIsActual()
+		{
+			Card c = new Card { Id = "AT_063t", Name = "Dreadscale", Type = "Minion" };
+			Assert.IsTrue(Game.IsActualCard(c));
 		}
 
 		[TestMethod]

--- a/Hearthstone Deck Tracker/Hearthstone/Game.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Game.cs
@@ -166,12 +166,14 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			CurrentGameStats.AddPlay(play, turn, cardId);
 		}
 
+		// TODO: possibly refactor with GetActualCards, reduce duplication
 		public static bool IsActualCard(Card card)
 		{
 			if(card == null)
 				return false;
 			return (card.Type == "Minion" || card.Type == "Spell" || card.Type == "Weapon")
-			       && Helper.IsNumeric(card.Id.ElementAt(card.Id.Length - 1)) && Helper.IsNumeric(card.Id.ElementAt(card.Id.Length - 2))
+			       && (Helper.IsNumeric(card.Id.ElementAt(card.Id.Length - 1)) || card.Id == "AT_063t")
+			       && Helper.IsNumeric(card.Id.ElementAt(card.Id.Length - 2))
 			       && !CardIds.InvalidCardIds.Any(id => card.Id.Contains(id));
 		}
 
@@ -849,7 +851,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 		{
 			return (from card in _cardDb.Values
 			        where card.Type == "Minion" || card.Type == "Spell" || card.Type == "Weapon"
-			        where Helper.IsNumeric(card.Id.ElementAt(card.Id.Length - 1))
+			        where Helper.IsNumeric(card.Id.ElementAt(card.Id.Length - 1)) || card.Id == "AT_063t"
 			        where Helper.IsNumeric(card.Id.ElementAt(card.Id.Length - 2))
 			        where !CardIds.InvalidCardIds.Any(id => card.Id.Contains(id))
 			        select card).ToList();


### PR DESCRIPTION
Dreadscale's id is *AT_063t*, the *t* stops it from being included in *ActualCards*.
Couldn't think of a better way than adding an id check at the relevant points, its not great but it works!
Fixes #1291