### PR TITLE
Add ability to create a new log reader instance

### DIFF
--- a/Hearthstone Deck Tracker/LogReader/HsLogReaderV2.cs
+++ b/Hearthstone Deck Tracker/LogReader/HsLogReaderV2.cs
@@ -49,9 +49,9 @@ namespace Hearthstone_Deck_Tracker.LogReader
                 Instance = new HsLogReaderV2();
         }
 
-        public static void Create(string hsDirectory, int updateDeclay, bool ifaceUpdateNeeded = true)
+        public static void Create(string hsDirectory, int updateDeclay, bool ifaceUpdateNeeded = true, bool forceNewInstance = false)
         {
-            if (Instance == null)
+            if (Instance == null || forceNewInstance)
                 Instance = new HsLogReaderV2(hsDirectory, updateDeclay, ifaceUpdateNeeded);
         }
 


### PR DESCRIPTION
The *import from log file* part of my *StatsConverter* plugin, needs to create a new LogReader instance. `HsLogReaderV2` introduced *null* checks on the *Create* methods, so I'm proposing a force option on the overloaded method (doesn't seem to be used anywhere, so the param shouldn't cause any problems).