### PR TITLE
fix bug about gold tracking

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -226,16 +226,20 @@ namespace Hearthstone_Deck_Tracker
 		[DefaultValue(0.075)]
 		public double GoldProgessY = 0.93;
 
-		[DefaultValue(new[] {0, 0, 0})]
-		//move this to some data file
-		public int[] GoldProgress = {0, 0, 0};
+        [DefaultValue(new[] { 0, 0, 0, 0, 0 })]
+        //move this to some data file
+        public int[] GoldProgress = { 0, 0, 0, 0, 0 };
 
-		//move this to some data file
-		public DateTime[] GoldProgressLastReset = {DateTime.MinValue, DateTime.MinValue, DateTime.MinValue};
+        //move this to some data file
+        public DateTime[] GoldProgressLastReset =
+        {
+            DateTime.MinValue, DateTime.MinValue, DateTime.MinValue,
+            DateTime.MinValue, DateTime.MinValue,
+        };
 
-		[DefaultValue(new[] {0, 0, 0})]
-		//move this to some data file
-		public int[] GoldProgressTotal = {0, 0, 0};
+        [DefaultValue(new[] { 0, 0, 0, 0, 0 })]
+        //move this to some data file
+        public int[] GoldProgressTotal = { 0, 0, 0, 0, 0 };
 
 		[DefaultValue(null)]
 		public bool? HearthStatsAutoDeleteDecks = null;

--- a/Hearthstone Deck Tracker/HsLogReader.cs
+++ b/Hearthstone Deck Tracker/HsLogReader.cs
@@ -722,6 +722,9 @@ namespace Hearthstone_Deck_Tracker
 								case Region.ASIA:
 									timeZone = TimeZoneInfo.FindSystemTimeZoneById("Korea Standard Time");
 									break;
+                                case Region.CHINA:
+							        timeZone = TimeZoneInfo.FindSystemTimeZoneById("China Standard Time");
+							        break;
 							}
 							if(timeZone != null)
 							{

--- a/Hearthstone Deck Tracker/LogReader/Handlers/RachelleHandler.cs
+++ b/Hearthstone Deck Tracker/LogReader/Handlers/RachelleHandler.cs
@@ -6,6 +6,21 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
 {
     public class RachelleHandler
     {
+        /// <summary>
+        /// [Rachelle] RewardUtils.GetViewableRewards() - processing reward [GoldRewardData: Amount=10 Origin=TOURNEY OriginData=0]
+        /// </summary>
+        private bool win3Times;
+
+        /// <summary>
+        /// [Rachelle] VictoryScreen.InitGoldRewardUI(): goldRewardState = INVALID
+        /// </summary>
+        private bool winCheck;
+
+        /// <summary>
+        /// count win times by 3 for a loop
+        /// </summary>
+        private int wins;
+
         public void Handle(string logLine, IHsGameState gameState, IGame game)
         {
             if (HsLogReaderConstants.CardAlreadyInCacheRegex.IsMatch(logLine))
@@ -16,57 +31,91 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
                 else
                     gameState.GameHandler.HandlePossibleConstructedCard(id, false);
             }
-            else if (HsLogReaderConstants.GoldProgressRegex.IsMatch(logLine)
-                     && (DateTime.Now - gameState.LastGameStart) > TimeSpan.FromSeconds(10)
+            else if ((DateTime.Now - gameState.LastGameStart) > TimeSpan.FromSeconds(10)
                      && game.CurrentGameMode != GameMode.Spectator)
             {
-                int wins;
-                var rawWins = HsLogReaderConstants.GoldProgressRegex.Match(logLine).Groups["wins"].Value;
-                if (int.TryParse(rawWins, out wins))
-                {
-                    TimeZoneInfo timeZone = null;
-                    switch (game.CurrentRegion)
-                    {
-                        case Region.EU:
-                            timeZone = TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time");
-                            break;
-                        case Region.US:
-                            timeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
-                            break;
-                        case Region.ASIA:
-                            timeZone = TimeZoneInfo.FindSystemTimeZoneById("Korea Standard Time");
-                            break;
-                        case Region.CHINA:
-                            timeZone = TimeZoneInfo.FindSystemTimeZoneById("China Standard Time");
-                            break;
-                    }
-                    if (timeZone != null)
-                    {
-                        var region = (int)game.CurrentRegion - 1;
-                        var date = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, timeZone).Date;
-                        if (Config.Instance.GoldProgressLastReset[region].Date != date)
-                        {
-                            Config.Instance.GoldProgressTotal[region] = 0;
-                            Config.Instance.GoldProgressLastReset[region] = date;
-                        }
-                        Config.Instance.GoldProgress[region] = wins == 3 ? 0 : wins;
-                        if (wins == 3)
-                            Config.Instance.GoldProgressTotal[region] += 10;
-                        Config.Save();
-                    }
-                }
+                GoldTracking(logLine, game);
             }
             else if (HsLogReaderConstants.DustRewardRegex.IsMatch(logLine))
             {
                 int amount;
-                if (int.TryParse(HsLogReaderConstants.DustRewardRegex.Match(logLine).Groups["amount"].Value, out amount))
+                if (int.TryParse(HsLogReaderConstants.DustRewardRegex.Match(logLine).Groups["amount"].Value,
+                    out amount))
                     gameState.GameHandler.HandleDustReward(amount);
             }
             else if (HsLogReaderConstants.GoldRewardRegex.IsMatch(logLine))
             {
                 int amount;
-                if (int.TryParse(HsLogReaderConstants.GoldRewardRegex.Match(logLine).Groups["amount"].Value, out amount))
+                if (int.TryParse(HsLogReaderConstants.GoldRewardRegex.Match(logLine).Groups["amount"].Value,
+                    out amount))
                     gameState.GameHandler.HandleGoldReward(amount);
+            }
+        }
+
+        private void GoldTracking(string logLine, IGame game)
+        {
+            if (
+                logLine.Equals(
+                    "[Rachelle] RewardUtils.GetViewableRewards() - processing reward [GoldRewardData: Amount=10 Origin=TOURNEY OriginData=0]"))
+            {
+                win3Times = true;
+            }
+            if (logLine.Equals("[Rachelle] VictoryScreen.InitGoldRewardUI(): goldRewardState = INVALID"))
+            {
+                winCheck = true;
+            }
+            if (winCheck)
+            {
+                winCheck = false;
+                TimeZoneInfo timeZone = null;
+                switch (game.CurrentRegion)
+                {
+                    case Region.EU:
+                        timeZone = TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time");
+                        break;
+                    case Region.US:
+                        timeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+                        break;
+                    case Region.ASIA:
+                        timeZone = TimeZoneInfo.FindSystemTimeZoneById("Korea Standard Time");
+                        break;
+                    case Region.CHINA:
+                        timeZone = TimeZoneInfo.FindSystemTimeZoneById("China Standard Time");
+                        break;
+                }
+                if (timeZone != null)
+                {
+                    wins++;
+                    var region = (int) game.CurrentRegion - 1;
+                    var date = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, timeZone).Date;
+                    if (Config.Instance.GoldProgressLastReset[region].Date != date)
+                    {
+                        wins = 1;
+                        Config.Instance.GoldProgressTotal[region] = 0;
+                        Config.Instance.GoldProgressLastReset[region] = date;
+                    }
+                    if (win3Times)
+                    {
+                        if (wins >= 4)
+                        {
+                            Logger.WriteLine(string.Format("Current wins is {0},{1} wins did not get gold reward.", wins,
+                                wins - 3));
+                        }
+                        wins = 0;
+                        win3Times = false;
+                        Config.Instance.GoldProgressTotal[region] += 10;
+                    }
+                    if (Config.Instance.GoldProgressTotal[region] == 100)
+                    {
+                        wins = 0;
+                    }
+                    Config.Instance.GoldProgress[region] = wins;
+                    Config.Save();
+                }
+                else
+                {
+                    Logger.WriteLine(string.Format("Can not recognize current region :{0}.", game.CurrentRegion));
+                }
             }
         }
     }

--- a/Hearthstone Deck Tracker/LogReader/Handlers/RachelleHandler.cs
+++ b/Hearthstone Deck Tracker/LogReader/Handlers/RachelleHandler.cs
@@ -85,8 +85,9 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
                 }
                 if (timeZone != null)
                 {
-                    wins++;
                     var region = (int) game.CurrentRegion - 1;
+                    wins = Config.Instance.GoldProgress[region];
+                    wins++;
                     var date = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, timeZone).Date;
                     if (Config.Instance.GoldProgressLastReset[region].Date != date)
                     {

--- a/Hearthstone Deck Tracker/LogReader/Handlers/RachelleHandler.cs
+++ b/Hearthstone Deck Tracker/LogReader/Handlers/RachelleHandler.cs
@@ -36,6 +36,9 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
                         case Region.ASIA:
                             timeZone = TimeZoneInfo.FindSystemTimeZoneById("Korea Standard Time");
                             break;
+                        case Region.CHINA:
+                            timeZone = TimeZoneInfo.FindSystemTimeZoneById("China Standard Time");
+                            break;
                     }
                     if (timeZone != null)
                     {

--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
@@ -711,8 +711,18 @@ namespace Hearthstone_Deck_Tracker
             var region = (int)_game.CurrentRegion - 1;
             if (region >= 0)
             {
-                LblGoldProgress.Text = string.Format("Wins: {0}/3 ({1}/100G)", Config.Instance.GoldProgress[region],
-                                                     Config.Instance.GoldProgressTotal[region]);
+                int wins = Config.Instance.GoldProgress[region];
+                if (wins < 3)
+                {
+                    LblGoldProgress.Text = string.Format("Wins: {0}/3 ({1}/100G)", wins,
+                        Config.Instance.GoldProgressTotal[region]);
+                }
+                else
+                {
+                    LblGoldProgress.Text = string.Format("At least {2} wins did not get gold reward , Wins: {0}/3 ({1}/100G) , ",
+                        wins,
+                        Config.Instance.GoldProgressTotal[region], wins - 2);
+                }
             }
         }
 


### PR DESCRIPTION
Hearthstone-Deck-Tracker\Hearthstone Deck Tracker\Windows\OverlayWindow.xaml.cs
private void UpdateGoldProgress()
        {
            var region = (int)_game.CurrentRegion - 1;
            if (region >= 0)
            {
                LblGoldProgress.Text = string.Format("Wins: {0}/3 ({1}/100G)", Config.Instance.GoldProgress[region],
                                                     Config.Instance.GoldProgressTotal[region]);
            }
        }

when _game.CurrentRegion is China 
  var region = (int)_game.CurrentRegion - 1;
region ==5-1=4

then the index region is out of GoldProgress and GoldProgressTotal,the same as GoldProgressLastReset
