### PR TITLE
Add extension to the Window class

### DIFF
--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
@@ -23,7 +23,7 @@ namespace Hearthstone_Deck_Tracker
     /// <summary>
     ///     Interaction logic for OverlayWindow.xaml
     /// </summary>
-    public partial class OverlayWindow
+    public partial class OverlayWindow : Window
     {
         private readonly GameV2 _game;
         private readonly int _customHeight;


### PR DESCRIPTION
This will allow (me in particular) people to access the underlying window attributes for resizing and focus, as well as make override (extension) methods without completely copying and personally modifying the code myself.

This makes for easier plugin development on my end while not costing anything to anyone else