### PR TITLE
Fix for gold progress in non-supporting modes

### DIFF
--- a/Hearthstone Deck Tracker/Hearthstone/GameV2.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/GameV2.cs
@@ -19,6 +19,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 		private static List<string> _hsLogLines = new List<string>();
 		public readonly List<Deck> DiscardedArenaDecks = new List<Deck>();
 		private GameMode _currentGameMode;
+        private GameMode _lastKnownGameMode;
 		public Deck TempArenaDeck;
 
 		public GameV2()
@@ -28,6 +29,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 
 			Entities = new Dictionary<int, Entity>();
 			CurrentGameMode = GameMode.None;
+            LastKnownGameMode = GameMode.None;
 			IsInMenu = true;
 			PossibleArenaCards = new List<Card>();
 			PossibleConstructedCards = new List<Card>();
@@ -73,10 +75,21 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			get { return _currentGameMode; }
 			set
 			{
+                LastKnownGameMode = _currentGameMode;
 				_currentGameMode = value;
 				Logger.WriteLine("set CurrentGameMode to " + value, "Game");
 			}
 		}
+
+        public GameMode LastKnownGameMode
+        {
+            get { return _lastKnownGameMode; }
+            set
+            {
+                _lastKnownGameMode = value;
+                Logger.WriteLine("set LastKnownGameMode to " + value, "Game");
+            }
+        }
 
 		public void Reset(bool resetStats = true)
 		{

--- a/Hearthstone Deck Tracker/Hearthstone/IGame.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/IGame.cs
@@ -19,6 +19,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
         bool IsRunning { get; set; }
         Region CurrentRegion { get; set; }
         GameMode CurrentGameMode { get; set; }
+        GameMode LastKnownGameMode { get; set; }
         GameStats CurrentGameStats { get; set; }
         OpponentSecrets OpponentSecrets { get; set; }
         List<Card> DrawnLastGame { get; set; }

--- a/Hearthstone Deck Tracker/LogReader/Handlers/RachelleHandler.cs
+++ b/Hearthstone Deck Tracker/LogReader/Handlers/RachelleHandler.cs
@@ -55,16 +55,21 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
 
         private void GoldTracking(string logLine, IGame game)
         {
-            if (
-                logLine.Contains(
-                    "RewardUtils.GetViewableRewards() - processing reward [GoldRewardData: Amount=10 Origin=TOURNEY OriginData=0]"))
+            if (game.LastKnownGameMode == GameMode.Arena || game.LastKnownGameMode == GameMode.Practice
+                || game.LastKnownGameMode == GameMode.Friendly)
+                return;
+
+            if (logLine.Contains(
+                "RewardUtils.GetViewableRewards() - processing reward [GoldRewardData: Amount=10 Origin=TOURNEY OriginData=0]"))
             {
                 win3Times = true;
             }
+
             if (logLine.Contains("VictoryScreen.InitGoldRewardUI(): goldRewardState = INVALID"))
             {
                 winCheck = true;
             }
+
             if (winCheck)
             {
                 winCheck = false;


### PR DESCRIPTION
Checks for the last known game mode and allows GoldTracking if the mode
supports it.

LastKnownGameMode (GameV2) allows this and gives the game mode of the
current game (while it is in progress).