### PR TITLE
Fix hero's being incorrectly assigned in Brawl (#1489, #1492)

### DIFF
--- a/Hearthstone Deck Tracker/FlyoutControls/DeckStatsControl.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/DeckStatsControl.xaml.cs
@@ -582,6 +582,13 @@ namespace Hearthstone_Deck_Tracker
 
 		private bool VerifyHeroes(GameStats game)
 		{
+			// If its Brawl skip verification
+			if(game.GameMode == GameMode.Brawl)
+			{
+				game.VerifiedHeroes = true;
+				return false;
+			}
+
 			var modifiedHero = false;
 			var playerHeroes = new Dictionary<string, int>();
 			var opponentHeroes = new Dictionary<string, int>();


### PR DESCRIPTION
So, it was the Hero Verification that was messing this up. A quick fix that just skips it for brawl. (As for the rest of the brawl craziness, no clue :stuck_out_tongue_winking_eye:)