### PR TITLE
Alternative Languages

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -584,6 +584,10 @@ namespace Hearthstone_Deck_Tracker
 		[DefaultValue("enUS")]
 		public string SelectedLanguage = "enUS";
 
+		[XmlArray(ElementName = "AlternativeLanguages")]
+		[XmlArrayItem(ElementName = "Language")]
+		public List<string> AlternativeLanguages = new List<string>();
+
 		[DefaultValue(GameMode.All)]
 		public GameMode SelectedStatsFilterGameMode = GameMode.All;
 

--- a/Hearthstone Deck Tracker/Controls/CardToolTipControl.xaml
+++ b/Hearthstone Deck Tracker/Controls/CardToolTipControl.xaml
@@ -12,6 +12,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Grid Grid.Row="0" Background="{DynamicResource AccentColorBrush}">
                 <Grid.ColumnDefinitions>
@@ -38,7 +39,11 @@
             <TextBlock Name="CardTextBlock" Text="{Binding Text}" Grid.Row="1" FontSize="14"
                        Foreground="{DynamicResource TextBrush}" VerticalAlignment="Top" FontWeight="Medium"
                        HorizontalAlignment="Center" TextWrapping="Wrap" Margin="10,0,10,0" TextAlignment="Center" />
-            <Grid Grid.Row="2" Background="{DynamicResource AccentColorBrush}">
+            <TextBlock Name="AlternativeLanguageText" Text="{Binding AlternativeLanguageText}" Grid.Row="2" FontSize="12"
+                       Foreground="#FF7F7F7F" VerticalAlignment="Top"
+                       Visibility="{Binding ShowAlternativeLanguageTextInTooltip}"
+                       HorizontalAlignment="Center" TextWrapping="Wrap" Margin="10,10,10,0" TextAlignment="Center" />
+            <Grid Grid.Row="3" Background="{DynamicResource AccentColorBrush}">
                 <hearthstoneDeckTracker:HearthstoneTextBlock Text="{Binding RaceOrType}" Grid.Column="1" FontSize="14"
                                             VerticalAlignment="Center" HorizontalAlignment="Center" TextWrapping="Wrap"
                                             TextAlignment="Center" />

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerAppearance.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerAppearance.xaml
@@ -51,18 +51,27 @@
                                                   VerticalAlignment="Top" Width="150"
                                                   SelectionChanged="ComboboxDeckLayout_SelectionChanged" />
                     </DockPanel>
-                    <DockPanel Margin="10,5,10,0">
-                        <Label Content="Language:" HorizontalAlignment="Left"
-                                               VerticalAlignment="Top" />
-                        <ComboBox Name="ComboboxLanguages" HorizontalAlignment="Right"
-                                                  VerticalAlignment="Top" Width="150"
-                                                  SelectionChanged="ComboboxLanguages_SelectionChanged" />
-                    </DockPanel>
-                    
                     <CheckBox x:Name="CheckboxDeckPickerCaps" Content="Use upper case deck names"
                                               HorizontalAlignment="Left" Margin="10,5,0,0"
                                               VerticalAlignment="Top" Checked="CheckboxDeckPickerCaps_Checked"
                                               Unchecked="CheckboxDeckPickerCaps_Unchecked" ToolTip="Uncheck to use normal case in Deck Picker."/>
+                    <GroupBox Header="Card Language" Margin="10,10,10,0">
+                        <StackPanel>
+                            <DockPanel Margin="0,5,0,0">
+                                <Label Content="Primary:" HorizontalAlignment="Left"
+                        			VerticalAlignment="Top" />
+                                <ComboBox x:Name="ComboboxLanguages" HorizontalAlignment="Right"
+                        			VerticalAlignment="Top" Width="170"
+                        			SelectionChanged="ComboboxLanguages_SelectionChanged" />
+                            </DockPanel>
+                            <DockPanel Margin="0,5,0,0">
+                                <Label x:Name="___No_Name_" Content="Alternatives:" HorizontalAlignment="Left"
+                            		VerticalAlignment="Top" ToolTip="Alternative languages are used in card search and tooltips" />
+                                <ListBox x:Name="ListBoxAlternativeLanguages" Height="120" Width="170" HorizontalAlignment="Right" />
+                            </DockPanel>
+                            <Label x:Name="label" Content="Restart HDT to apply language changes"/>
+                        </StackPanel>
+                    </GroupBox>
                     <Button Name="ButtonRestart" Margin="10,15,10,0" Content="restart hdt" Click="ButtonRestart_OnClick"/>
                 </StackPanel>
             </ScrollViewer>

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerAppearance.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerAppearance.xaml.cs
@@ -1,6 +1,7 @@
 ﻿#region
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Windows;
@@ -83,21 +84,61 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 
 		private void ComboboxLanguages_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			if(!_initialized)
-				return;
 			var language = ComboboxLanguages.SelectedValue.ToString();
-			if(!Helper.LanguageDict.ContainsKey(language))
+			UpdateAlternativeLanguageList(language);
+
+			if (!_initialized)
 				return;
 
+			if (!IsLanguageAvailable(language))
+				return;			
+			
 			var selectedLanguage = Helper.LanguageDict[language];
-
-			if(!File.Exists(string.Format("Files/cardDB.{0}.xml", selectedLanguage)))
-				return;
 
 			Config.Instance.SelectedLanguage = selectedLanguage;
 			Config.Save();
+		}
 
-			Helper.MainWindow.ShowMessage("Restart required.", "Please restart HDT for this setting to take effect.");
+		private bool IsLanguageAvailable(string language)
+		{
+			if (!Helper.LanguageDict.ContainsKey(language))
+				return false;																	  
+
+			return File.Exists(string.Format("Files/cardDB.{0}.xml", Helper.LanguageDict[language]));
+		}
+
+		private void UpdateAlternativeLanguageList(string primaryLanguage)
+		{
+			ListBoxAlternativeLanguages.Items.Clear();
+			foreach (var pair in Helper.LanguageDict)
+			{
+				var box = new CheckBox();
+				box.Content = pair.Key;
+				if (pair.Key == primaryLanguage) {
+					box.IsEnabled = false;
+				} else {
+					box.IsChecked =	Config.Instance.AlternativeLanguages.Contains(pair.Value);
+					box.Unchecked += CheckboxAlternativeLanguageToggled;
+					box.Checked += CheckboxAlternativeLanguageToggled;
+                }
+				ListBoxAlternativeLanguages.Items.Add(box);
+			}
+		}
+
+		private void CheckboxAlternativeLanguageToggled(object sender, RoutedEventArgs e)
+		{
+			if(!_initialized)
+				return;
+
+			var languages = new List<string>();
+			foreach (CheckBox box in ListBoxAlternativeLanguages.Items)
+			{
+				string language = (string)box.Content;
+				if (box.IsChecked == true && IsLanguageAvailable(language))
+					languages.Add(Helper.LanguageDict[language]);
+			}			 
+			Config.Instance.AlternativeLanguages = languages;
+			Config.Save();
 		}
 
 		private void ComboboxIconSet_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/Hearthstone Deck Tracker/Hearthstone/Card.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Card.cs
@@ -161,7 +161,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 		[XmlIgnore]
 		public Visibility ShowAlternativeLanguageTextInTooltip
 		{
-			get { return AlternativeNames.Count > 0 ? Visibility.Visible : Visibility.Hidden; }
+			get { return AlternativeNames.Count > 0 ? Visibility.Visible : Visibility.Collapsed; }
 		}
 
 		[XmlIgnore]

--- a/Hearthstone Deck Tracker/Hearthstone/Card.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Card.cs
@@ -1,6 +1,7 @@
 ﻿#region
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -50,7 +51,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 
 		public Card(string id, string playerClass, string rarity, string type, string name, int cost, string localizedName, int inHandCount,
 		            int count, string text, string englishText, int attack, int health, string race, string[] mechanics, int? durability, string artist,
-		            string set)
+		            string set, List<string> alternativeNames = null, List<string> alternativeTexts = null)
 		{
 			Id = id;
 			PlayerClass = playerClass;
@@ -70,6 +71,10 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			Mechanics = mechanics;
 			Artist = artist;
 			Set = set;
+			if (alternativeNames != null)
+				AlternativeNames = alternativeNames;
+			if (alternativeTexts != null)
+				AlternativeTexts = alternativeTexts;
 		}
 
 		public int Count
@@ -123,6 +128,40 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 								   .Replace("#", "")
 								   .Replace("\\n", "\n") : null;
 			}
+		}
+
+		[XmlIgnore]
+		public string AlternativeLanguageText
+		{
+			get
+			{
+				string result = "";
+				for (int i = 0; i < AlternativeNames.Count; ++i)
+				{
+					if (i > 0)
+					{
+						result += "-\n";
+					}
+					result += "[" + AlternativeNames[i] + "]\n";
+					if (AlternativeTexts[i] != null)
+					{						 
+						result += AlternativeTexts[i].Replace("<b>", "")
+									   .Replace("</b>", "")
+									   .Replace("<i>", "")
+									   .Replace("</i>", "")
+									   .Replace("$", "")
+									   .Replace("#", "")
+									   .Replace("\\n", "\n")  + "\n";
+					}
+				}
+				return result.TrimEnd(new char[]{' ', '\n'});
+			}
+		}
+
+		[XmlIgnore]
+		public Visibility ShowAlternativeLanguageTextInTooltip
+		{
+			get { return AlternativeNames.Count > 0 ? Visibility.Visible : Visibility.Hidden; }
 		}
 
 		[XmlIgnore]
@@ -202,6 +241,12 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			get { return string.IsNullOrEmpty(_localizedName) ? Name : _localizedName; }
 			set { _localizedName = value; }
 		}
+
+		[XmlIgnore]
+		public List<string> AlternativeNames = new List<string>();
+
+		[XmlIgnore]
+		public List<string> AlternativeTexts = new List<string>();
 
 		[XmlIgnore]
 		public int InHandCount
@@ -400,7 +445,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 		public object Clone()
 		{
 			var newcard = new Card(Id, PlayerClass, Rarity, Type, Name, Cost, LocalizedName, InHandCount, Count, Text, EnglishText, Attack, Health, Race,
-			                       Mechanics, Durability, Artist, Set);
+			                       Mechanics, Durability, Artist, Set, AlternativeNames, AlternativeTexts);
 			return newcard;
 		}
 
@@ -451,6 +496,8 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			Mechanics = stats.Mechanics;
 			Artist = stats.Artist;
 			Set = stats.Set;
+			AlternativeNames = stats.AlternativeNames;
+			AlternativeTexts = stats.AlternativeTexts;
 			_loaded = true;
 			OnPropertyChanged();
 		}

--- a/Hearthstone Deck Tracker/Hearthstone/Database.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Database.cs
@@ -51,6 +51,34 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 				if(_cards == null)
 					_cards = new Dictionary<string, Card>();
 			}
+
+			foreach (string altnativeLanguage in Config.Instance.AlternativeLanguages)
+			{
+				if (altnativeLanguage == language)
+					continue;
+				try
+				{
+					LoadAlternativeLanguage(altnativeLanguage);
+				}
+				catch (Exception e)
+				{
+					Logger.WriteLine("Error loading alternative language " + altnativeLanguage + ": \n" + e, "Game");
+				} 
+			}
+		}
+
+		private static void LoadAlternativeLanguage(string language)
+		{
+			var alternative = XmlManager<CardDb>.Load(string.Format("Files/cardDB.{0}.xml", language));
+			foreach(var card in alternative.Cards)
+			{
+				Card c;
+				if(_cards.TryGetValue(card.CardId, out c))
+				{
+					c.AlternativeNames.Add(card.Name);
+					c.AlternativeTexts.Add(card.Text);
+				}
+			}
 		}
 
 		public static Card GetCardFromId(string cardId)

--- a/Hearthstone Deck Tracker/Hearthstone/Database.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Database.cs
@@ -75,6 +75,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 				Card c;
 				if(_cards.TryGetValue(card.CardId, out c))
 				{
+					if (card.Name == null) continue;
 					c.AlternativeNames.Add(card.Name);
 					c.AlternativeTexts.Add(card.Text);
 				}

--- a/Hearthstone Deck Tracker/MainWindow/MainWindow_NewDeck.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow_NewDeck.cs
@@ -76,12 +76,15 @@ namespace Hearthstone_Deck_Tracker
 				{
 					var cardName = Helper.RemoveDiacritics(card.LocalizedName.ToLowerInvariant(), true);
 					if(!Config.Instance.UseFullTextSearch && !cardName.Contains(formattedInput)
+					   && card.AlternativeNames.All((x) => !Helper.RemoveDiacritics(x.ToLowerInvariant(), true).Contains(formattedInput))
 					   && (!string.IsNullOrEmpty(card.RaceOrType) && formattedInput != card.RaceOrType.ToLowerInvariant()))
 						continue;
 					if(Config.Instance.UseFullTextSearch
 					   && words.Any(
 					                w =>
 					                !cardName.Contains(w) && !(!string.IsNullOrEmpty(card.Text) && card.Text.ToLowerInvariant().Contains(w))
+					                && card.AlternativeNames.All((x) => !Helper.RemoveDiacritics(x.ToLowerInvariant(), true).Contains(formattedInput))
+					                && card.AlternativeTexts.All((x) => !x.ToLowerInvariant().Contains(formattedInput))
 					                && (!string.IsNullOrEmpty(card.RaceOrType) && w != card.RaceOrType.ToLowerInvariant())
 					                && (!string.IsNullOrEmpty(card.Rarity) && w != card.Rarity.ToLowerInvariant())))
 						continue;

--- a/Hearthstone Deck Tracker/MainWindow/MainWindow_NewDeck.cs
+++ b/Hearthstone Deck Tracker/MainWindow/MainWindow_NewDeck.cs
@@ -84,7 +84,7 @@ namespace Hearthstone_Deck_Tracker
 					                w =>
 					                !cardName.Contains(w) && !(!string.IsNullOrEmpty(card.Text) && card.Text.ToLowerInvariant().Contains(w))
 					                && card.AlternativeNames.All((x) => !Helper.RemoveDiacritics(x.ToLowerInvariant(), true).Contains(formattedInput))
-					                && card.AlternativeTexts.All((x) => !x.ToLowerInvariant().Contains(formattedInput))
+					                && card.AlternativeTexts.All((x) => x == null || !x.ToLowerInvariant().Contains(formattedInput))
 					                && (!string.IsNullOrEmpty(card.RaceOrType) && w != card.RaceOrType.ToLowerInvariant())
 					                && (!string.IsNullOrEmpty(card.Rarity) && w != card.Rarity.ToLowerInvariant())))
 						continue;


### PR DESCRIPTION
Add an "Alternative Languages" option, which is a list of languages, allowing the player to:

- Search cards using these languages
- View texts of these languages in card tooltip

This is quite useful for players active in HS communities of different languages.

Screenshot:

![altlang](https://cloud.githubusercontent.com/assets/445459/10115934/d41c9904-644e-11e5-857d-e0ab0bf573f4.png)

