### PR TITLE
Secret Deduction

### DIFF
--- a/HDTTests/Hearthstone/SecretTests.cs
+++ b/HDTTests/Hearthstone/SecretTests.cs
@@ -120,7 +120,7 @@ namespace HDTTests.Hearthstone
         public void SingleSecret_MinionDied()
         {
             //TODO: this behaviour is not always true. https://www.youtube.com/watch?v=oHdveuZXoHg
-            _gameEventHandler.HandlePlayerMinionDeath();
+            _gameEventHandler.HandleOpponentMinionDeath();
             VerifySecrets(0, HunterSecrets.All);
             VerifySecrets(1, MageSecrets.All, MageSecrets.Duplicate, MageSecrets.Effigy);
             VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.Avenge, PaladinSecrets.Redemption);

--- a/HDTTests/Hearthstone/SecretTests.cs
+++ b/HDTTests/Hearthstone/SecretTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Collections.Generic;
 using Hearthstone_Deck_Tracker;
 using Hearthstone_Deck_Tracker.Enums;
 using Hearthstone_Deck_Tracker.Enums.Hearthstone;
@@ -135,8 +136,7 @@ namespace HDTTests.Hearthstone
         public void SingleSecret_OnlyMinionDied()
         {
             _opponentMinion2.SetTag(GAME_TAG.ZONE, (int)TAG_ZONE.HAND);
-            //TODO: this behaviour is not always true. https://www.youtube.com/watch?v=oHdveuZXoHg
-            _gameEventHandler.HandleOpponentMinionDeath();
+            _gameEventHandler.HandleOpponentMinionDeath(_opponentMinion1, 2);
             VerifySecrets(0, HunterSecrets.All);
             VerifySecrets(1, MageSecrets.All, MageSecrets.Duplicate, MageSecrets.Effigy);
             VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.Redemption);
@@ -146,8 +146,7 @@ namespace HDTTests.Hearthstone
         public void SingleSecret_OneMinionDied()
         {
             _opponentMinion2.SetTag(GAME_TAG.ZONE, (int)TAG_ZONE.PLAY);
-            //TODO: this behaviour is not always true. https://www.youtube.com/watch?v=oHdveuZXoHg
-            _gameEventHandler.HandleOpponentMinionDeath();
+            _gameEventHandler.HandleOpponentMinionDeath(_opponentMinion1, 2);
             VerifySecrets(0, HunterSecrets.All);
             VerifySecrets(1, MageSecrets.All, MageSecrets.Duplicate, MageSecrets.Effigy);
             VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.Avenge, PaladinSecrets.Redemption);
@@ -207,7 +206,7 @@ namespace HDTTests.Hearthstone
             VerifySecrets(2, PaladinSecrets.All);
         }
 
-        private void VerifySecrets(int secretIndex, string[] allSecrets, params string[] triggered)
+        private void VerifySecrets(int secretIndex, List<string> allSecrets, params string[] triggered)
         {
             var secrets = _game.OpponentSecrets.Secrets[secretIndex];
             foreach (var secret in allSecrets)

--- a/HDTTests/Hearthstone/SecretTests.cs
+++ b/HDTTests/Hearthstone/SecretTests.cs
@@ -74,13 +74,13 @@ namespace HDTTests.Hearthstone
         public void SingleSecret_HeroToHero_PlayerAttackTest()
         {
             _minion1.SetTag(GAME_TAG.ZONE, (int)TAG_ZONE.HAND);
-            _gameEventHandler.HandlePlayerAttack(_heroPlayer, _heroOpponent);
+            _game.OpponentSecrets.ZeroFromAttack(_heroPlayer, _heroOpponent);
             VerifySecrets(0, HunterSecrets.All, HunterSecrets.BearTrap, HunterSecrets.ExplosiveTrap);
             VerifySecrets(1, MageSecrets.All, MageSecrets.IceBarrier);
             VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.NobleSacrifice);
 
             _minion1.SetTag(GAME_TAG.ZONE, (int) TAG_ZONE.PLAY);
-            _gameEventHandler.HandlePlayerAttack(_heroPlayer, _heroOpponent);
+            _game.OpponentSecrets.ZeroFromAttack(_heroPlayer, _heroOpponent);
             VerifySecrets(0, HunterSecrets.All, HunterSecrets.BearTrap, HunterSecrets.ExplosiveTrap,
                              HunterSecrets.Misdirection);
             VerifySecrets(1, MageSecrets.All, MageSecrets.IceBarrier);
@@ -91,7 +91,7 @@ namespace HDTTests.Hearthstone
         public void SingleSecret_MinionToHero_PlayerAttackTest()
         {
             _minion1.SetTag(GAME_TAG.ZONE, (int)TAG_ZONE.PLAY);
-            _gameEventHandler.HandlePlayerAttack(_minion1, _heroOpponent);
+            _game.OpponentSecrets.ZeroFromAttack(_minion1, _heroOpponent);
             VerifySecrets(0, HunterSecrets.All, HunterSecrets.BearTrap, HunterSecrets.ExplosiveTrap,
                 HunterSecrets.FreezingTrap, HunterSecrets.Misdirection);
             VerifySecrets(1, MageSecrets.All, MageSecrets.IceBarrier, MageSecrets.Vaporize);
@@ -101,7 +101,7 @@ namespace HDTTests.Hearthstone
         [TestMethod]
         public void SingleSecret_HeroToMinion_PlayerAttackTest()
         {
-            _gameEventHandler.HandlePlayerAttack(_heroPlayer, _minion2);
+            _game.OpponentSecrets.ZeroFromAttack(_heroPlayer, _minion2);
             VerifySecrets(0, HunterSecrets.All, HunterSecrets.SnakeTrap);
             VerifySecrets(1, MageSecrets.All);
             VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.NobleSacrifice);
@@ -110,7 +110,7 @@ namespace HDTTests.Hearthstone
         [TestMethod]
         public void SingleSecret_MinionToMinion_PlayerAttackTest()
         {
-            _gameEventHandler.HandlePlayerAttack(_minion1, _minion2);
+            _game.OpponentSecrets.ZeroFromAttack(_minion1, _minion2);
             VerifySecrets(0, HunterSecrets.All, HunterSecrets.FreezingTrap, HunterSecrets.SnakeTrap);
             VerifySecrets(1, MageSecrets.All);
             VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.NobleSacrifice);

--- a/HDTTests/Hearthstone/SecretTests.cs
+++ b/HDTTests/Hearthstone/SecretTests.cs
@@ -67,14 +67,22 @@ namespace HDTTests.Hearthstone
             //_gameEventHandler.HandleOpponentSecretPlayed(_secretMage2, "", 0, 0, false, _secretMage2.Id);
             _gameEventHandler.HandleOpponentSecretPlayed(_secretPaladin1, "", 0, 0, false, _secretPaladin1.Id);
             //_gameEventHandler.HandleOpponentSecretPlayed(_secretPaladin2, "", 0, 0, false, _secretPaladin2.Id);
+            _game.Entities.Add(0, _minion1);
         }
 
         [TestMethod]
         public void SingleSecret_HeroToHero_PlayerAttackTest()
         {
+            _minion1.SetTag(GAME_TAG.ZONE, (int)TAG_ZONE.HAND);
+            _gameEventHandler.HandlePlayerAttack(_heroPlayer, _heroOpponent);
+            VerifySecrets(0, HunterSecrets.All, HunterSecrets.BearTrap, HunterSecrets.ExplosiveTrap);
+            VerifySecrets(1, MageSecrets.All, MageSecrets.IceBarrier);
+            VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.NobleSacrifice);
+
+            _minion1.SetTag(GAME_TAG.ZONE, (int) TAG_ZONE.PLAY);
             _gameEventHandler.HandlePlayerAttack(_heroPlayer, _heroOpponent);
             VerifySecrets(0, HunterSecrets.All, HunterSecrets.BearTrap, HunterSecrets.ExplosiveTrap,
-                HunterSecrets.Misdirection);
+                             HunterSecrets.Misdirection);
             VerifySecrets(1, MageSecrets.All, MageSecrets.IceBarrier);
             VerifySecrets(2, PaladinSecrets.All, PaladinSecrets.NobleSacrifice);
         }
@@ -82,6 +90,7 @@ namespace HDTTests.Hearthstone
         [TestMethod]
         public void SingleSecret_MinionToHero_PlayerAttackTest()
         {
+            _minion1.SetTag(GAME_TAG.ZONE, (int)TAG_ZONE.PLAY);
             _gameEventHandler.HandlePlayerAttack(_minion1, _heroOpponent);
             VerifySecrets(0, HunterSecrets.All, HunterSecrets.BearTrap, HunterSecrets.ExplosiveTrap,
                 HunterSecrets.FreezingTrap, HunterSecrets.Misdirection);

--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -307,15 +307,18 @@ namespace Hearthstone_Deck_Tracker
 
             // redemption never triggers if a deathrattle effect fills up the board
             // effigy can trigger ahead of the deathrattle effect, but only if effigy was played before the deathrattle minion
-            // todo: need to properly break ties when effigy + deathrattle played in same turn
             if (_game.OpponentMinionCount < 7 - numDeathrattleMinions)
             {
                 _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.Redemption);
-
+                _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Effigy);
+            }
+            else
+            {
+                // todo: need to properly break ties when effigy + deathrattle played in same turn
                 int minionTurnPlayed = turn - entity.GetTag(GAME_TAG.NUM_TURNS_IN_PLAY);
                 SecretHelper secret = _game.OpponentSecrets.Secrets.FirstOrDefault(x => x.TurnPlayed >= minionTurnPlayed);
                 int secretOffset = secret != null ? _game.OpponentSecrets.Secrets.IndexOf(secret) : 0;
-                _game.OpponentSecrets.SetZeroNewer(CardIds.Secrets.Mage.Effigy, secretOffset);
+                _game.OpponentSecrets.SetZeroOlder(CardIds.Secrets.Mage.Effigy, secretOffset);
             }
 
             if (Helper.MainWindow != null)

--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -281,11 +281,10 @@ namespace Hearthstone_Deck_Tracker
             if (!Config.Instance.AutoGrayoutSecrets)
                 return;
 
-            if (isMinionTargeted)
-            {
-                _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Spellbender);
-            }
             _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Counterspell);
+
+            if (isMinionTargeted)
+                _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Spellbender);
 
             if(Helper.MainWindow != null)
                 Helper.MainWindow.Overlay.ShowSecrets();
@@ -297,11 +296,18 @@ namespace Hearthstone_Deck_Tracker
                 return;
 
             _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Duplicate);
-            _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Effigy);
-            _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.Redemption);
 
-            if (_game.IsOpponentMinionInPlay)
+            if (_game.OpponentMinionCount > 0)
                 _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.Avenge);
+
+            // todo: redemption (and maybe effigy) won't trigger if a deathrattle effect fills up the board
+            // example: opponent has 7 minions and you kill their sludge belcher
+            // this conditional is wrong because _game.OpponentMinionCount equals 6 in the above scenario
+            if (_game.OpponentMinionCount < 7)
+            {
+                _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Effigy);
+                _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.Redemption);
+            }
 
             if (Helper.MainWindow != null)
                 Helper.MainWindow.Overlay.ShowSecrets();

--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -300,6 +300,11 @@ namespace Hearthstone_Deck_Tracker
             if (_game.OpponentMinionCount > 0)
                 _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.Avenge);
 
+            // Minion first: no effigy trigger
+            // Minion after: effigy trigger
+            // Minion first: no redemption trigger
+            // Minion after: no redemption trigger
+
             // todo: redemption (and maybe effigy) won't trigger if a deathrattle effect fills up the board
             // example: opponent has 7 minions and you kill their sludge belcher
             // this conditional is wrong because _game.OpponentMinionCount equals 6 in the above scenario
@@ -1002,7 +1007,7 @@ namespace Hearthstone_Deck_Tracker
 		        if(!Enum.TryParse(_game.Opponent.Class, out heroClass))
 			        return;
 	        }
-			_game.OpponentSecrets.NewSecretPlayed(heroClass, otherId, false);
+			_game.OpponentSecrets.NewSecretPlayed(heroClass, otherId, turn);
 
             if (Helper.MainWindow != null)
                 Helper.MainWindow.Overlay.ShowSecrets();

--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -291,16 +291,19 @@ namespace Hearthstone_Deck_Tracker
                 Helper.MainWindow.Overlay.ShowSecrets();
         }
 
-        public void HandlePlayerMinionDeath()
+        public void HandleOpponentMinionDeath()
         {
             if (!Config.Instance.AutoGrayoutSecrets)
                 return;
+
             _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Duplicate);
             _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Effigy);
-            _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.Avenge);
             _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.Redemption);
 
-            if(Helper.MainWindow != null)
+            if (_game.IsOpponentMinionInPlay)
+                _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.Avenge);
+
+            if (Helper.MainWindow != null)
                 Helper.MainWindow.Overlay.ShowSecrets();
         }
 
@@ -797,10 +800,13 @@ namespace Hearthstone_Deck_Tracker
 			_game.Player.PlayToGraveyard(entity, cardId, turn);
 	    }
 
-	    public void HandleOpponentPlayToGraveyard(Entity entity, string cardId, int turn)
-		{
-			_game.Opponent.PlayToGraveyard(entity, cardId, turn);
-		}
+        public void HandleOpponentPlayToGraveyard(Entity entity, string cardId, int turn)
+        {
+            _game.Opponent.PlayToGraveyard(entity, cardId, turn);
+
+            if (entity.IsMinion)
+                HandleOpponentMinionDeath();
+        }
 
 	    public void HandlePlayerCreateInPlay(Entity entity, string cardId, int turn)
 	    {

--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -253,48 +253,14 @@ namespace Hearthstone_Deck_Tracker
         {
             _attackingEntity = entity;
             if(_attackingEntity != null && _defendingEntity != null)
-                HandlePlayerAttack(_attackingEntity, _defendingEntity);
+                _game.OpponentSecrets.ZeroFromAttack(_attackingEntity, _defendingEntity);
         }
 
         public void HandleDefendingEntity(Entity entity)
         {
             _defendingEntity = entity;
             if(_attackingEntity != null && _defendingEntity != null)
-                HandlePlayerAttack(_attackingEntity, _defendingEntity);
-        }
-
-        public void HandlePlayerAttack(Entity source, Entity target)
-        {
-            if (!Config.Instance.AutoGrayoutSecrets)
-                return;
-
-            _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.NobleSacrifice, HeroClass.Paladin);
-
-            if (target.IsHero)
-            {
-                _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.BearTrap, HeroClass.Hunter);
-                _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.ExplosiveTrap, HeroClass.Hunter);
-                _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.IceBarrier, HeroClass.Mage);
-
-                if (_game.IsMinionInPlay)
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.Misdirection, HeroClass.Hunter);
-
-                if (source.IsMinion)
-                {
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Vaporize, HeroClass.Mage);
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.FreezingTrap, HeroClass.Hunter);
-                }
-            }
-            else
-            {
-                _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.SnakeTrap, HeroClass.Hunter);
-
-                if (source.IsMinion)
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.FreezingTrap, HeroClass.Hunter);
-            }
-
-            if (Helper.MainWindow != null)
-                Helper.MainWindow.Overlay.ShowSecrets();
+                _game.OpponentSecrets.ZeroFromAttack(_attackingEntity, _defendingEntity);
         }
 
         public void HandlePlayerMinionPlayed()
@@ -302,9 +268,9 @@ namespace Hearthstone_Deck_Tracker
             if (!Config.Instance.AutoGrayoutSecrets)
                 return;
 
-            _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.Snipe, HeroClass.Hunter);
-            _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.MirrorEntity, HeroClass.Mage);
-            _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.Repentance, HeroClass.Paladin);
+            _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.Snipe);
+            _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.MirrorEntity);
+            _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.Repentance);
 
             if (Helper.MainWindow != null)
                 Helper.MainWindow.Overlay.ShowSecrets();
@@ -317,9 +283,9 @@ namespace Hearthstone_Deck_Tracker
 
             if (isMinionTargeted)
             {
-                _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Spellbender, HeroClass.Mage);
+                _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Spellbender);
             }
-            _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Counterspell, HeroClass.Mage);
+            _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Counterspell);
 
             if(Helper.MainWindow != null)
                 Helper.MainWindow.Overlay.ShowSecrets();
@@ -329,10 +295,10 @@ namespace Hearthstone_Deck_Tracker
         {
             if (!Config.Instance.AutoGrayoutSecrets)
                 return;
-            _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Duplicate, HeroClass.Mage);
-            _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Effigy, HeroClass.Mage);
-            _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.Avenge, HeroClass.Paladin);
-            _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.Redemption, HeroClass.Paladin);
+            _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Duplicate);
+            _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Effigy);
+            _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.Avenge);
+            _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.Redemption);
 
             if(Helper.MainWindow != null)
                 Helper.MainWindow.Overlay.ShowSecrets();
@@ -345,7 +311,7 @@ namespace Hearthstone_Deck_Tracker
 
             if (entity.IsOpponent)
             {
-                _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.EyeForAnEye, HeroClass.Paladin);
+                _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.EyeForAnEye);
                 if(Helper.MainWindow != null)
                     Helper.MainWindow.Overlay.ShowSecrets();
             }
@@ -358,7 +324,7 @@ namespace Hearthstone_Deck_Tracker
 
             if (entity.IsMinion)
             {
-                _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.CompetitiveSpirit, HeroClass.Paladin);
+                _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.CompetitiveSpirit);
                 if(Helper.MainWindow != null)
                     Helper.MainWindow.Overlay.ShowSecrets();
             }
@@ -1053,15 +1019,18 @@ namespace Hearthstone_Deck_Tracker
         public void HandleOpponentSecretTrigger(Entity entity, string cardId, int turn, int otherId)
         {
             LogEvent("OpponentSecretTrigger", cardId);
-			_game.Opponent.SecretTriggered(entity, turn);
+            _game.Opponent.SecretTriggered(entity, turn);
             _game.OpponentSecretCount--;
-            _game.OpponentSecrets.SecretRemoved(otherId);
+            _game.OpponentSecrets.SecretRemoved(otherId, cardId);
+
             if (_game.OpponentSecretCount <= 0)
                 Helper.MainWindow.Overlay.HideSecrets();
             else
             {
                 if (Config.Instance.AutoGrayoutSecrets)
-                    _game.OpponentSecrets.SetZero(cardId, null);
+                {
+                    _game.OpponentSecrets.SetZero(cardId);
+                }
                 Helper.MainWindow.Overlay.ShowSecrets();
 			}
 			Helper.UpdateOpponentCards();

--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -268,40 +268,29 @@ namespace Hearthstone_Deck_Tracker
             if (!Config.Instance.AutoGrayoutSecrets)
                 return;
 
-            if (source.IsHero)
+            _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.NobleSacrifice, HeroClass.Paladin);
+
+            if (target.IsHero)
             {
-                if (target.IsHero)
-                {
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.BearTrap, HeroClass.Hunter);
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.ExplosiveTrap, HeroClass.Hunter);
+                _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.BearTrap, HeroClass.Hunter);
+                _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.ExplosiveTrap, HeroClass.Hunter);
+                _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.IceBarrier, HeroClass.Mage);
+
+                if (_game.IsMinionInPlay)
                     _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.Misdirection, HeroClass.Hunter);
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.IceBarrier, HeroClass.Mage);
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.NobleSacrifice, HeroClass.Paladin);
-                }
-                else
+
+                if (source.IsMinion)
                 {
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.SnakeTrap, HeroClass.Hunter);
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.NobleSacrifice, HeroClass.Paladin);
+                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Vaporize, HeroClass.Mage);
+                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.FreezingTrap, HeroClass.Hunter);
                 }
             }
             else
             {
-                if (target.IsHero)
-                {
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.BearTrap, HeroClass.Hunter);
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.ExplosiveTrap, HeroClass.Hunter);
+                _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.SnakeTrap, HeroClass.Hunter);
+
+                if (source.IsMinion)
                     _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.FreezingTrap, HeroClass.Hunter);
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.Misdirection, HeroClass.Hunter);
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.IceBarrier, HeroClass.Mage);
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Vaporize, HeroClass.Mage);
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.NobleSacrifice, HeroClass.Paladin);
-                }
-                else
-                {
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.FreezingTrap, HeroClass.Hunter);
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.SnakeTrap, HeroClass.Hunter);
-                    _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.NobleSacrifice, HeroClass.Paladin);
-                }
             }
 
             if (Helper.MainWindow != null)
@@ -313,11 +302,11 @@ namespace Hearthstone_Deck_Tracker
             if (!Config.Instance.AutoGrayoutSecrets)
                 return;
 
-            _game.OpponentSecrets.SetZero("EX1_609", HeroClass.Hunter); //snipe
-            _game.OpponentSecrets.SetZero("EX1_294", HeroClass.Mage); //mirror entity
-            _game.OpponentSecrets.SetZero("EX1_379", HeroClass.Paladin); //repentance
-            
-            if(Helper.MainWindow != null)
+            _game.OpponentSecrets.SetZero(CardIds.Secrets.Hunter.Snipe, HeroClass.Hunter);
+            _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.MirrorEntity, HeroClass.Mage);
+            _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.Repentance, HeroClass.Paladin);
+
+            if (Helper.MainWindow != null)
                 Helper.MainWindow.Overlay.ShowSecrets();
         }
 
@@ -328,9 +317,9 @@ namespace Hearthstone_Deck_Tracker
 
             if (isMinionTargeted)
             {
-                _game.OpponentSecrets.SetZero("tt_010", HeroClass.Mage); //spellbender
+                _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Spellbender, HeroClass.Mage);
             }
-            _game.OpponentSecrets.SetZero("EX1_287", HeroClass.Mage); //counterspell
+            _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Counterspell, HeroClass.Mage);
 
             if(Helper.MainWindow != null)
                 Helper.MainWindow.Overlay.ShowSecrets();
@@ -340,11 +329,10 @@ namespace Hearthstone_Deck_Tracker
         {
             if (!Config.Instance.AutoGrayoutSecrets)
                 return;
-
-            _game.OpponentSecrets.SetZero("FP1_018", HeroClass.Mage); //duplicate
-            _game.OpponentSecrets.SetZero("AT_002", HeroClass.Mage); //effigy
-            _game.OpponentSecrets.SetZero("FP1_020", HeroClass.Paladin); //avenge
-            _game.OpponentSecrets.SetZero("EX1_136", HeroClass.Paladin); //redemption
+            _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Duplicate, HeroClass.Mage);
+            _game.OpponentSecrets.SetZero(CardIds.Secrets.Mage.Effigy, HeroClass.Mage);
+            _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.Avenge, HeroClass.Paladin);
+            _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.Redemption, HeroClass.Paladin);
 
             if(Helper.MainWindow != null)
                 Helper.MainWindow.Overlay.ShowSecrets();
@@ -357,7 +345,7 @@ namespace Hearthstone_Deck_Tracker
 
             if (entity.IsOpponent)
             {
-                _game.OpponentSecrets.SetZero("EX1_132", HeroClass.Paladin); //eye for an eye
+                _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.EyeForAnEye, HeroClass.Paladin);
                 if(Helper.MainWindow != null)
                     Helper.MainWindow.Overlay.ShowSecrets();
             }
@@ -370,7 +358,7 @@ namespace Hearthstone_Deck_Tracker
 
             if (entity.IsMinion)
             {
-                _game.OpponentSecrets.SetZero("AT_073", HeroClass.Paladin); //competitive spirit
+                _game.OpponentSecrets.SetZero(CardIds.Secrets.Paladin.CompetitiveSpirit, HeroClass.Paladin);
                 if(Helper.MainWindow != null)
                     Helper.MainWindow.Overlay.ShowSecrets();
             }

--- a/Hearthstone Deck Tracker/Hearthstone/CardIds.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/CardIds.cs
@@ -94,41 +94,6 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
             };
         }
 
-        [Obsolete("Use Secrets.Hunter.All")]
-        public static readonly List<string> SecretIdsHunter = new List<string>
-		{
-			"AT_060",  //bear trap
-			"EX1_610", //explosive trap
-			"EX1_611", //freezing trap
-			"EX1_533", //misdirection
-			"EX1_609", //snipe
-			"EX1_554"  //snake trap
-		};
-
-        [Obsolete("Use Secrets.Mage.All")]
-        public static readonly List<string> SecretIdsMage = new List<string>
-		{
-			"EX1_287", //counterspell
-			"FP1_018", //duplicate
-			"AT_002",  //effigy
-            "EX1_289", //ice barrier
-			"EX1_295", //ice block
-			"EX1_294", //mirror entity
-			"tt_010",  //spellbender
-			"EX1_594"  //vaporize
-		};
-
-        [Obsolete("Use Secrets.Paladin.All")]
-        public static readonly List<string> SecretIdsPaladin = new List<string>
-		{
-			"FP1_020", //avenge
-			"AT_073",  //competitive spirit
-            "EX1_132", //eye for an eye
-			"EX1_130", //noble sacrifice
-			"EX1_136", //redemption
-			"EX1_379"  //repentance
-		};
-
         public static readonly Dictionary<string, string[]> SubCardIds = new Dictionary<string, string[]>
 		{
 			{

--- a/Hearthstone Deck Tracker/Hearthstone/CardIds.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/CardIds.cs
@@ -44,9 +44,9 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
         {
             public static class Hunter
             {
-                public static string[] All
+                public static List<string> All
                 {
-                    get { return new[] { BearTrap, ExplosiveTrap, FreezingTrap, Misdirection, Snipe, SnakeTrap }; }
+                    get { return new List<string> { BearTrap, ExplosiveTrap, FreezingTrap, Misdirection, Snipe, SnakeTrap }; }
                 }
 
                 public static string BearTrap { get { return "AT_060"; } }
@@ -58,9 +58,9 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
             }
             public static class Mage
             {
-                public static string[] All
+                public static List<string> All
                 {
-                    get { return new[] { Counterspell, Duplicate, Effigy, IceBarrier, IceBlock, MirrorEntity, Spellbender, Vaporize }; }
+                    get { return new List<string> { Counterspell, Duplicate, Effigy, IceBarrier, IceBlock, MirrorEntity, Spellbender, Vaporize }; }
                 }
                 public static string Counterspell { get { return "EX1_287"; } }
                 public static string Duplicate { get { return "FP1_018"; } }
@@ -73,9 +73,9 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
             }
             public static class Paladin
             {
-                public static string[] All
+                public static List<string> All
                 {
-                    get { return new[] { Avenge, CompetitiveSpirit, EyeForAnEye, NobleSacrifice, Redemption, Repentance }; }
+                    get { return new List<string> { Avenge, CompetitiveSpirit, EyeForAnEye, NobleSacrifice, Redemption, Repentance }; }
                 }
                 public static string Avenge { get { return "FP1_020"; } }
                 public static string CompetitiveSpirit { get { return "AT_073"; } }
@@ -94,6 +94,24 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
             };
         }
 
+        // todo: spells which add deathrattle. Soul of the Forest, Ancestral Spirit
+        // todo: conditional deathrattle summons: Voidcaller, Stalagg/Feugen
+        // todo: Baron Rivendare
+        public static readonly Dictionary<string, int> DeathrattleSummonCardIds = new Dictionary<string, int>
+        {
+            { "EX1_534", 2 }, // Savannah Highmane
+            { "AT_036", 1 }, // Anub'arak
+            { "AT_019", 1 }, // Dreadsteed
+            { "EX1_110", 1 }, // Cairne Bloodhoof
+            { "EX1_556", 1 }, // Harvest Golem
+            { "GVG_096", 1 }, // Piloted Shredder
+            { "GVG_105", 1 }, // Piloted Sky Golem
+            { "GVG_114", 1 }, // Sneed's Old Shredder
+            { "FP1_002", 2 }, // Haunted Creeper
+            { "FP1_007", 1 }, // Nerubian Egg
+            { "FP1_012", 1 }, // Sludge Belcher
+        };
+        
         public static readonly Dictionary<string, string[]> SubCardIds = new Dictionary<string, string[]>
 		{
 			{

--- a/Hearthstone Deck Tracker/Hearthstone/CardIds.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/CardIds.cs
@@ -48,6 +48,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
                 {
                     get { return new[] { BearTrap, ExplosiveTrap, FreezingTrap, Misdirection, Snipe, SnakeTrap }; }
                 }
+
                 public static string BearTrap { get { return "AT_060"; } }
                 public static string ExplosiveTrap { get { return "EX1_610"; } }
                 public static string FreezingTrap { get { return "EX1_611"; } }
@@ -83,6 +84,14 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
                 public static string Redemption { get { return "EX1_136"; } }
                 public static string Repentance { get { return "EX1_379"; } }
             }
+
+            public static List<string> FastCombat = new List<string> {
+                Hunter.FreezingTrap,
+                Hunter.ExplosiveTrap,
+                Hunter.Misdirection,
+                Paladin.NobleSacrifice,
+                Mage.Vaporize
+            };
         }
 
         [Obsolete("Use Secrets.Hunter.All")]

--- a/Hearthstone Deck Tracker/Hearthstone/Entities/Entity.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Entities/Entity.cs
@@ -37,11 +37,17 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Entities
 
         [JsonIgnore]
         public bool IsHero
-	    {
-	        get { return CardId != null && CardIds.HeroIdDict.Keys.Contains(CardId); }
-	    }
+        {
+            get { return CardId != null && CardIds.HeroIdDict.Keys.Contains(CardId); }
+        }
 
-		[JsonIgnore]
+        [JsonIgnore]
+        public bool IsActiveDeathrattle
+        {
+            get { return HasTag(GAME_TAG.DEATHRATTLE) && GetTag(GAME_TAG.DEATHRATTLE) == 1; }
+        }
+
+        [JsonIgnore]
 		public bool IsOpponent
 		{
 			get { return !IsPlayer && HasTag(GAME_TAG.CARDTYPE) && (GetTag(GAME_TAG.CARDTYPE) == (int)TAG_CARDTYPE.HERO); }

--- a/Hearthstone Deck Tracker/Hearthstone/GameV2.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/GameV2.cs
@@ -75,7 +75,12 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
             get { return Entities.FirstOrDefault(x => (x.Value.IsInPlay && x.Value.IsMinion)).Value != null; }
         }
 
-		public GameMode CurrentGameMode
+        public bool IsOpponentMinionInPlay
+        {
+            get { return Entities.FirstOrDefault(x => (x.Value.IsInPlay && x.Value.IsMinion && x.Value.IsControlledBy(Opponent.Id))).Value != null; }
+        }
+
+        public GameMode CurrentGameMode
 		{
 			get { return _currentGameMode; }
 			set

--- a/Hearthstone Deck Tracker/Hearthstone/GameV2.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/GameV2.cs
@@ -70,6 +70,11 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			}
 		}
 
+        public bool IsMinionInPlay
+        {
+            get { return Entities.FirstOrDefault(x => (x.Value.IsInPlay && x.Value.IsMinion)).Value != null; }
+        }
+
 		public GameMode CurrentGameMode
 		{
 			get { return _currentGameMode; }

--- a/Hearthstone Deck Tracker/Hearthstone/GameV2.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/GameV2.cs
@@ -80,6 +80,11 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
             get { return Entities.FirstOrDefault(x => (x.Value.IsInPlay && x.Value.IsMinion && x.Value.IsControlledBy(Opponent.Id))).Value != null; }
         }
 
+        public int OpponentMinionCount
+        {
+            get { return Entities.Count(x => (x.Value.IsInPlay && x.Value.IsMinion && x.Value.IsControlledBy(Opponent.Id))); }
+        }
+
         public GameMode CurrentGameMode
 		{
 			get { return _currentGameMode; }

--- a/Hearthstone Deck Tracker/Hearthstone/GameV2.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/GameV2.cs
@@ -32,7 +32,7 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			IsInMenu = true;
 			PossibleArenaCards = new List<Card>();
 			PossibleConstructedCards = new List<Card>();
-			OpponentSecrets = new OpponentSecrets();
+			OpponentSecrets = new OpponentSecrets(this);
 		}
 
 		public static List<string> HSLogLines

--- a/Hearthstone Deck Tracker/Hearthstone/Secrets/OpponentSecrets.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Secrets/OpponentSecrets.cs
@@ -154,18 +154,12 @@ namespace Hearthstone_Deck_Tracker
 
         public void SetZero(string cardId)
         {
-            SetZeroNewer(cardId, 0);
+            SetZeroOlder(cardId, Secrets.Count);
         }
 
         public void SetZeroOlder(string cardId, int stopIndex)
         {
             for (int index = 0; index < stopIndex; index++)
-                Secrets[index].PossibleSecrets[cardId] = false;
-        }
-
-        public void SetZeroNewer(string cardId, int startIndex)
-        {
-            for (int index = startIndex; index < Secrets.Count; index++)
                 Secrets[index].PossibleSecrets[cardId] = false;
         }
 

--- a/Hearthstone Deck Tracker/Hearthstone/Secrets/OpponentSecrets.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Secrets/OpponentSecrets.cs
@@ -59,9 +59,9 @@ namespace Hearthstone_Deck_Tracker
 			return heroClass;
 		}
 
-		public void NewSecretPlayed(HeroClass heroClass, int id, bool stolen)
+		public void NewSecretPlayed(HeroClass heroClass, int id, int turn)
 		{
-			Secrets.Add(new SecretHelper(heroClass, id, stolen));
+			Secrets.Add(new SecretHelper(heroClass, id, turn));
 			Logger.WriteLine("Added secret with id:" + id, "OpponentSecrets");
 		}
 

--- a/Hearthstone Deck Tracker/Hearthstone/Secrets/OpponentSecrets.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Secrets/OpponentSecrets.cs
@@ -134,21 +134,6 @@ namespace Hearthstone_Deck_Tracker
 			Logger.WriteLine("Cleared secrets", "OpponentSecrets");
 		}
 
-		public void LogSecretState()
-		{
-			Logger.WriteLine("Secrets. Count: " + Secrets.Count, "OpponentSecrets");
-			int i = 0;
-			foreach (var secret in Secrets)
-			{
-				Logger.WriteLine("Secret " + i + " Stolen: " + secret.Stolen + " HeroClass " + secret.HeroClass.ToString());
-				foreach(var poss in secret.PossibleSecrets)
-				{
-					Logger.WriteLine(poss.Key + " " + poss.Value);
-				}
-				i++;
-			}
-		}
-
 		public void SetMax(string cardId, HeroClass? heroClass)
 		{
 			if(heroClass == null)
@@ -162,8 +147,6 @@ namespace Hearthstone_Deck_Tracker
 			{
 				secret.PossibleSecrets[cardId] = true;
 			}
-
-			LogSecretState();
 		}
 
         public void SetZero(string cardId, int? cutoff = null)
@@ -172,13 +155,10 @@ namespace Hearthstone_Deck_Tracker
 
             for (int index = 0; index < cutoff; index++)
                 Secrets[index].PossibleSecrets[cardId] = false;
-
-            LogSecretState();
         }
 
 		public List<Secret> GetSecrets()
 		{
-			LogSecretState();
 			var returnThis = DisplayedClasses.SelectMany(SecretHelper.GetSecretIds).Select(cardId => new Secret(cardId, 0)).ToList();
 
 			foreach (var secret in Secrets)

--- a/Hearthstone Deck Tracker/Hearthstone/Secrets/OpponentSecrets.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Secrets/OpponentSecrets.cs
@@ -89,39 +89,42 @@ namespace Hearthstone_Deck_Tracker
             Logger.WriteLine("Removed secret with id:" + id, "OpponentSecrets");
         }
 
-        public void ZeroFromAttack(Entity attacker, Entity defender, bool fastOnly = false, int? index = null)
+        public void ZeroFromAttack(Entity attacker, Entity defender, bool fastOnly = false, int stopIndex = -1)
         {
             if (!Config.Instance.AutoGrayoutSecrets)
                 return;
 
-            SetZero(CardIds.Secrets.Paladin.NobleSacrifice, index);
+            if (stopIndex == -1)
+                stopIndex = Secrets.Count;
+
+            SetZeroOlder(CardIds.Secrets.Paladin.NobleSacrifice, stopIndex);
 
             if (defender.IsHero)
             {
                 if (!fastOnly)
                 {
-                    SetZero(CardIds.Secrets.Hunter.BearTrap, index);
-                    SetZero(CardIds.Secrets.Mage.IceBarrier, index);
+                    SetZeroOlder(CardIds.Secrets.Hunter.BearTrap, stopIndex);
+                    SetZeroOlder(CardIds.Secrets.Mage.IceBarrier, stopIndex);
                 }
 
-                SetZero(CardIds.Secrets.Hunter.ExplosiveTrap, index);
+                SetZeroOlder(CardIds.Secrets.Hunter.ExplosiveTrap, stopIndex);
 
                 if (Game.IsMinionInPlay)
-                    SetZero(CardIds.Secrets.Hunter.Misdirection, index);
+                    SetZeroOlder(CardIds.Secrets.Hunter.Misdirection, stopIndex);
 
                 if (attacker.IsMinion)
                 {
-                    SetZero(CardIds.Secrets.Mage.Vaporize, index);
-                    SetZero(CardIds.Secrets.Hunter.FreezingTrap, index);
+                    SetZeroOlder(CardIds.Secrets.Mage.Vaporize, stopIndex);
+                    SetZeroOlder(CardIds.Secrets.Hunter.FreezingTrap, stopIndex);
                 }
             }
             else
             {
                 if (!fastOnly)
-                    SetZero(CardIds.Secrets.Hunter.SnakeTrap, index);
+                    SetZeroOlder(CardIds.Secrets.Hunter.SnakeTrap, stopIndex);
 
                 if (attacker.IsMinion)
-                    SetZero(CardIds.Secrets.Hunter.FreezingTrap, index);
+                    SetZeroOlder(CardIds.Secrets.Hunter.FreezingTrap, stopIndex);
             }
 
             if (Helper.MainWindow != null)
@@ -149,15 +152,24 @@ namespace Hearthstone_Deck_Tracker
 			}
 		}
 
-        public void SetZero(string cardId, int? cutoff = null)
+        public void SetZero(string cardId)
         {
-            cutoff = cutoff ?? Secrets.Count;
+            SetZeroNewer(cardId, 0);
+        }
 
-            for (int index = 0; index < cutoff; index++)
+        public void SetZeroOlder(string cardId, int stopIndex)
+        {
+            for (int index = 0; index < stopIndex; index++)
                 Secrets[index].PossibleSecrets[cardId] = false;
         }
 
-		public List<Secret> GetSecrets()
+        public void SetZeroNewer(string cardId, int startIndex)
+        {
+            for (int index = startIndex; index < Secrets.Count; index++)
+                Secrets[index].PossibleSecrets[cardId] = false;
+        }
+
+        public List<Secret> GetSecrets()
 		{
 			var returnThis = DisplayedClasses.SelectMany(SecretHelper.GetSecretIds).Select(cardId => new Secret(cardId, 0)).ToList();
 

--- a/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretHelper.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretHelper.cs
@@ -11,10 +11,10 @@ namespace Hearthstone_Deck_Tracker
 	public class SecretHelper
 	{
 
-		public SecretHelper(HeroClass heroClass, int id, bool stolen)
+		public SecretHelper(HeroClass heroClass, int id, int turnPlayed)
 		{
 			Id = id;
-			Stolen = stolen;
+            TurnPlayed = turnPlayed;
 			HeroClass = heroClass;
 			PossibleSecrets = new Dictionary<string, bool>();
 
@@ -25,7 +25,7 @@ namespace Hearthstone_Deck_Tracker
 		}
 
 		public int Id { get; private set; }
-		public bool Stolen { get; private set; }
+		public int TurnPlayed { get; private set; }
 		public HeroClass HeroClass { get; private set; }
 		public Dictionary<string, bool> PossibleSecrets { get; set; }
 

--- a/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretHelper.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Secrets/SecretHelper.cs
@@ -40,11 +40,11 @@ namespace Hearthstone_Deck_Tracker
 			switch(heroClass)
 			{
 				case HeroClass.Hunter:
-					return CardIds.SecretIdsHunter;
+					return CardIds.Secrets.Hunter.All;
 				case HeroClass.Mage:
-					return CardIds.SecretIdsMage;
+					return CardIds.Secrets.Mage.All;
 				case HeroClass.Paladin:
-					return CardIds.SecretIdsPaladin;
+					return CardIds.Secrets.Paladin.All;
 				default:
 					return new List<string>();
 			}

--- a/Hearthstone Deck Tracker/IGameHandler.cs
+++ b/Hearthstone Deck Tracker/IGameHandler.cs
@@ -47,7 +47,7 @@ namespace Hearthstone_Deck_Tracker
         void HandleDefendingEntity(Entity entity);
         void HandlePlayerMinionPlayed();
         void HandlePlayerSpellPlayed(bool isMinionTargeted);
-        void HandlePlayerMinionDeath();
+        void HandleOpponentMinionDeath();
         void HandleOpponentDamage(Entity entity);
         void HandleOpponentTurnStart(Entity entity);
 

--- a/Hearthstone Deck Tracker/IGameHandler.cs
+++ b/Hearthstone Deck Tracker/IGameHandler.cs
@@ -43,9 +43,8 @@ namespace Hearthstone_Deck_Tracker
 
         #region SecretTriggers
 
-        void HandlePlayerAttack(Entity source, Entity target);
-	    void HandleAttackingEntity(Entity entity);
-	    void HandleDefendingEntity(Entity entity);
+        void HandleAttackingEntity(Entity entity);
+        void HandleDefendingEntity(Entity entity);
         void HandlePlayerMinionPlayed();
         void HandlePlayerSpellPlayed(bool isMinionTargeted);
         void HandlePlayerMinionDeath();

--- a/Hearthstone Deck Tracker/IGameHandler.cs
+++ b/Hearthstone Deck Tracker/IGameHandler.cs
@@ -47,7 +47,7 @@ namespace Hearthstone_Deck_Tracker
         void HandleDefendingEntity(Entity entity);
         void HandlePlayerMinionPlayed();
         void HandlePlayerSpellPlayed(bool isMinionTargeted);
-        void HandleOpponentMinionDeath();
+        void HandleOpponentMinionDeath(Entity entity, int turn);
         void HandleOpponentDamage(Entity entity);
         void HandleOpponentTurnStart(Entity entity);
 
@@ -74,7 +74,7 @@ namespace Hearthstone_Deck_Tracker
 
 		void HandleOpponentJoust(Entity entity, string cardId, int turn);
 		void HandlePlayerPlayToGraveyard(Entity entity, string cardId, int turn);
-		void HandleOpponentPlayToGraveyard(Entity entity, string cardId, int turn);
+        void HandleOpponentPlayToGraveyard(Entity entity, string cardId, int turn, bool playersTurn);
 		void HandlePlayerCreateInPlay(Entity entity, string cardId, int turn);
 		void HandleOpponentCreateInPlay(Entity entity, string cardId, int turn);
 		void HandleZonePositionUpdate(ActivePlayer player, TAG_ZONE tagZone, int turn);

--- a/Hearthstone Deck Tracker/LogReader/Handlers/TagChangeHandler.cs
+++ b/Hearthstone Deck Tracker/LogReader/Handlers/TagChangeHandler.cs
@@ -397,6 +397,14 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
                 if (player == "FRIENDLY")
                     gameState.GameHandler.HandleAttackingEntity(value == 1 ? game.Entities[id] : null);
             }
+            else if (tag == GAME_TAG.PROPOSED_DEFENDER)
+            {
+                game.OpponentSecrets.proposedDefenderEntityId = value;
+            }
+            else if (tag == GAME_TAG.PROPOSED_ATTACKER)
+            {
+                game.OpponentSecrets.proposedAttackerEntityId = value;
+            }
             else if (tag == GAME_TAG.NUM_MINIONS_PLAYED_THIS_TURN && value > 0)
             {
                 if (gameState.PlayersTurn())

--- a/Hearthstone Deck Tracker/LogReader/Handlers/TagChangeHandler.cs
+++ b/Hearthstone Deck Tracker/LogReader/Handlers/TagChangeHandler.cs
@@ -412,13 +412,6 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
                     gameState.GameHandler.HandlePlayerMinionPlayed();
                 }
             }
-            else if (tag == GAME_TAG.NUM_FRIENDLY_MINIONS_THAT_DIED_THIS_TURN && value > 0)
-            {
-                if (gameState.PlayersTurn() && player == "OPPOSING")
-                {
-                    gameState.GameHandler.HandlePlayerMinionDeath();
-                }
-            }
             else if (tag == GAME_TAG.PREDAMAGE && value > 0)
             {
                 if (gameState.PlayersTurn())

--- a/Hearthstone Deck Tracker/LogReader/Handlers/TagChangeHandler.cs
+++ b/Hearthstone Deck Tracker/LogReader/Handlers/TagChangeHandler.cs
@@ -261,9 +261,9 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
 	                                }
                                     else if(controller == game.Opponent.Id)
 									{
-										gameState.GameHandler.HandleOpponentPlayToGraveyard(game.Entities[id], cardId,
-																						   gameState.GetTurnNumber());
-										if(game.Entities[id].HasTag(GAME_TAG.HEALTH))
+                                        gameState.GameHandler.HandleOpponentPlayToGraveyard(game.Entities[id], cardId,
+                                                                                           gameState.GetTurnNumber(), gameState.PlayersTurn());
+                                        if (game.Entities[id].HasTag(GAME_TAG.HEALTH))
 											gameState.ProposeKeyPoint(KeyPointType.Death, id, ActivePlayer.Opponent);
                                     }
 		                        break;


### PR DESCRIPTION
This patches some of the edge cases surrounding combat.

When a "fast secret" gets triggered, sometimes it can disrupt combat (freezing trap, for example, will prevent the attack from going through). Any secrets older than the triggered secret need to be narrowed down based on the proposed combat.

On hero->hero combat, misdirection was being hidden even if there were no other targets. There needs to be a minion in play for misdirection to trigger.
