### PR TITLE
Try to fix Win 8/10 exporting issue

### DIFF
--- a/Hearthstone Deck Tracker/DeckExporter.cs
+++ b/Hearthstone Deck Tracker/DeckExporter.cs
@@ -221,6 +221,16 @@ namespace Hearthstone_Deck_Tracker
 				SendKeys.SendWait(fixedName);
 			SendKeys.SendWait("{ENTER}");
 
+			Version win8version = new Version(6, 2, 9200, 0);
+			if (Environment.OSVersion.Version >= win8version) {
+				// The second ENTER is to workaround exporting issues in Win 8/10.
+				// If HS detects it's a tablet, or the software "Touch Keyboard" was opened on a
+				// non-tablet machine, the game will use a new and buggy search box in the upper-right,
+				// causing strange behaviors. This workaround looks strange too, but just works.
+				// See https://github.com/ko-vasilev/Hearthstone-Collection-Tracker/issues/25#issuecomment-135025630
+				SendKeys.SendWait("{ENTER}");
+			}
+
 			Logger.WriteLine("try to export card: " + card.Name, "DeckExporter", 1);
 			await Task.Delay(Config.Instance.DeckExportDelay * 2);
 


### PR DESCRIPTION
This may fix #1341.

The workaround looks pretty unreasonable but the Win 10 HS search box is
even more mysterious. The current solution is indeed the most direct and
reliable method concluded from hours of trial-and-error.

For more details, see:
https://github.com/ko-vasilev/Hearthstone-Collection-Tracker/issues/25#issuecomment-135025630

I was okay win Win 7 compatibility mode. However, one of my friends was experiencing serious decrease in game 3D performance with compatibility mode enabled. I have tested this patch in my Win 10 laptop. 