### PR TITLE
Add option to disable auto filtering on export

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -217,6 +217,9 @@ namespace Hearthstone_Deck_Tracker
 		[DefaultValue(1)]
 		public int ExportStartDelay = 1;
 
+		[DefaultValue(true)]
+		public bool EnableExportAutoFilter = true;
+
 		[DefaultValue(false)]
 		public bool ExtraFeatures = false;
 

--- a/Hearthstone Deck Tracker/DeckExporter.cs
+++ b/Hearthstone Deck Tracker/DeckExporter.cs
@@ -64,7 +64,8 @@ namespace Hearthstone_Deck_Tracker
 				if(Config.Instance.ExportSetDeckName && !deck.TagList.ToLower().Contains("brawl"))
 					await SetDeckName(deck.Name, ratio, hsRect.Width, hsRect.Height, hsHandle);
 
-				await ClickAllCrystal(ratio, hsRect.Width, hsRect.Height, hsHandle);
+				if (Config.Instance.EnableExportAutoFilter)
+					await ClickAllCrystal(ratio, hsRect.Width, hsRect.Height, hsHandle);
 
 				Logger.WriteLine("Creating deck...", "DeckExporter");
 				deck.MissingCards.Clear();

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerExporting.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerExporting.xaml
@@ -42,6 +42,10 @@
                                               HorizontalAlignment="Left" Margin="10,5,0,0"
                                               VerticalAlignment="Top" Checked="CheckboxAutoClear_Checked"
                                               Unchecked="CheckboxAutoClear_Unchecked" />
+                    <CheckBox x:Name="CheckboxAutoClearFilters" Content="Auto clear filters"
+                                              HorizontalAlignment="Left" Margin="10,5,0,0"
+                                              VerticalAlignment="Top" Checked="CheckboxAutoClearFilters_Checked"
+                                              Unchecked="CheckboxAutoClearFilters_Unchecked" />
                     <CheckBox x:Name="CheckboxExportPasteClipboard"
                                               Content="Paste names from clipboard"
                                               ToolTip="Try this if you have problems exporting certain card/deck names - May not work with all keyboard layouts"

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerExporting.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerExporting.xaml.cs
@@ -28,6 +28,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			CheckboxGoldenFeugen.IsChecked = Config.Instance.OwnsGoldenFeugen;
 			CheckboxGoldenStalagg.IsChecked = Config.Instance.OwnsGoldenStalagg;
 			CheckboxAutoClear.IsChecked = Config.Instance.AutoClearDeck;
+			CheckboxAutoClearFilters.IsChecked = Config.Instance.EnableExportAutoFilter;
 			TextboxExportDelay.Text = Config.Instance.ExportStartDelay.ToString();
 			CheckboxShowDialog.IsChecked = Config.Instance.ShowExportingDialog;
 
@@ -158,6 +159,22 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			if(!_initialized)
 				return;
 			Config.Instance.AutoClearDeck = false;
+			Config.Save();
+		}
+
+		private void CheckboxAutoClearFilters_Checked(object sender, RoutedEventArgs e)
+		{
+			if(!_initialized)
+				return;
+			Config.Instance.EnableExportAutoFilter = true;
+			Config.Save();
+		}
+
+		private void CheckboxAutoClearFilters_Unchecked(object sender, RoutedEventArgs e)
+		{
+			if(!_initialized)
+				return;
+			Config.Instance.EnableExportAutoFilter = false;
 			Config.Save();
 		}
 


### PR DESCRIPTION
An option to disable the mana cost and card set auto filtering, it might help people having trouble exporting decks (#1217, #1177)?