### PR TITLE
Quick fixes

### DIFF
--- a/HDTTests/BoardDamage/BoardCardTest.cs
+++ b/HDTTests/BoardDamage/BoardCardTest.cs
@@ -63,6 +63,34 @@ namespace HDTTests.BoardDamage
 		}
 
 		[TestMethod]
+		public void DontInclude_IfInDeckZoneAndAttacked()
+		{
+			var card = _minion.Deck().AttacksThisTurn(1).ToBoardCard();
+			Assert.IsFalse(card.Include);	
+		}
+
+		[TestMethod]
+		public void DontInclude_IfInHandZoneAndWindfuryAttackedTwice()
+		{
+			var card = _minion.Hand().Windfury().AttacksThisTurn(2).ToBoardCard();
+			Assert.IsFalse(card.Include);
+		}
+
+		[TestMethod]
+		public void Include_IfInDeckHandAndNotAttacked()
+		{
+			var card = _minion.Hand().AttacksThisTurn(0).ToBoardCard();
+			Assert.IsTrue(card.Include);
+		}
+
+		[TestMethod]
+		public void Include_IfInDeckZoneAndWindfuryAttackedOnce()
+		{
+			var card = _minion.Deck().Windfury().AttacksThisTurn(1).ToBoardCard();
+			Assert.IsTrue(card.Include);
+		}
+
+		[TestMethod]
 		public void Include_IfExhaustedAndCharged()
 		{
 			var card = _minion.Exhausted().Charge().AttacksThisTurn(0).ToBoardCard();

--- a/HDTTests/BoardDamage/PlayerBoardTest.cs
+++ b/HDTTests/BoardDamage/PlayerBoardTest.cs
@@ -25,10 +25,6 @@ namespace HDTTests.BoardDamage
 			_cards.Add(new EntityBuilder("", 3, 1).InPlay().Charge().ToCardEntity());
 			_cards.Add(new EntityBuilder("", 3, 1).InPlay().Windfury().ToCardEntity());
 			_cards.Add(new EntityBuilder("", 2, 2).InPlay().Exhausted().ToCardEntity());
-
-			_exceptions = new List<CardEntity>();
-			var icehowl = new EntityBuilder("AT_125", 10, 10).InPlay().ToCardEntity();
-			_exceptions.Add(icehowl);
 		}
 
 		[TestMethod]
@@ -54,12 +50,11 @@ namespace HDTTests.BoardDamage
 		}
 
 		[TestMethod]
-		// TODO: ignore Icehowl for now, if taunts were to be included
-		//		could add back in with special attrib
-		public void IgnoreSpecialCases()
+		public void IgnoreGraveyard()
 		{
-			var board = new PlayerBoard(_exceptions, true);
-			Assert.AreEqual(0, board.Cards.Count);
+			_cards.Add(new EntityBuilder("", 3, 3).Graveyard().ToCardEntity());
+			var board = new PlayerBoard(_cards, true);
+			Assert.AreEqual(6, board.Cards.Count);
 		}
 
 		[TestMethod]

--- a/HDTTests/BoardDamage/TestHelper.cs
+++ b/HDTTests/BoardDamage/TestHelper.cs
@@ -102,6 +102,24 @@ namespace HDTTests.BoardDamage
 			return this;
 		}
 
+		public EntityBuilder Graveyard()
+		{
+			_instance.SetTag(GAME_TAG.ZONE, (int)TAG_ZONE.GRAVEYARD);
+			return this;
+		}
+
+		public EntityBuilder Deck()
+		{
+			_instance.SetTag(GAME_TAG.ZONE, (int)TAG_ZONE.DECK);
+			return this;
+		}
+
+		public EntityBuilder Hand()
+		{
+			_instance.SetTag(GAME_TAG.ZONE, (int)TAG_ZONE.HAND);
+			return this;
+		}
+
 		public EntityBuilder Invalid()
 		{
 			_instance.SetTag(GAME_TAG.ZONE, (int)TAG_ZONE.INVALID);

--- a/Hearthstone Deck Tracker/Utility/BoardDamage/BoardCard.cs
+++ b/Hearthstone Deck Tracker/Utility/BoardDamage/BoardCard.cs
@@ -124,6 +124,23 @@ namespace Hearthstone_Deck_Tracker.Utility.BoardDamage
 					return false;
 				}
 			}
+			// sometimes cards seem to be in wrong zone while in play,
+			// these cards don't become exhausted, so check attacks.
+			else if (Zone.ToLower() == "deck" || Zone.ToLower() == "hand")
+			{
+				if(_windfury && _attacksThisTurn >= 2)
+				{
+					return false;
+				}
+				else if(!_windfury && _attacksThisTurn >= 1)
+				{
+					return false;
+				}
+				else
+				{
+					return true;
+				}
+			}
 			else
 			{
 				return true;

--- a/Hearthstone Deck Tracker/Utility/BoardDamage/PlayerBoard.cs
+++ b/Hearthstone Deck Tracker/Utility/BoardDamage/PlayerBoard.cs
@@ -71,7 +71,7 @@ namespace Hearthstone_Deck_Tracker.Utility.BoardDamage
 				&& x.Entity.GetTag(GAME_TAG.CARDTYPE) != (int)TAG_CARDTYPE.ENCHANTMENT
 				&& x.Entity.GetTag(GAME_TAG.CARDTYPE) != (int)TAG_CARDTYPE.HERO_POWER
 				&& x.Entity.GetTag(GAME_TAG.ZONE) != (int)TAG_ZONE.SETASIDE
-				&& x.CardId != "AT_125" // Icehowl
+				&& x.Entity.GetTag(GAME_TAG.ZONE) != (int)TAG_ZONE.GRAVEYARD
 				).ToList<CardEntity>();
 		}
 	}

--- a/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/OverlayWindow.xaml.cs
@@ -469,7 +469,7 @@ namespace Hearthstone_Deck_Tracker
 
             var holdingNextTurn2 = Math.Round(100.0f * Helper.DrawProbability(2, (cardsLeftInDeck + handWithoutCoin), handWithoutCoin + 1), 1);
             var drawNextTurn2 = Math.Round(200.0f / cardsLeftInDeck, 1);
-            LblOpponentDrawChance2.Text = drawNextTurn2 + "%";
+            LblOpponentDrawChance2.Text = (cardsLeftInDeck == 1 ? 100 : drawNextTurn2) + "%";
             LblOpponentHandChance2.Text = holdingNextTurn2 + "%";
 
             var holdingNextTurn = Math.Round(100.0f * Helper.DrawProbability(1, (cardsLeftInDeck + handWithoutCoin), handWithoutCoin + 1), 1);
@@ -495,7 +495,8 @@ namespace Hearthstone_Deck_Tracker
             }
             LblPlayerFatigue.Text = "";
 
-            LblDrawChance2.Text = Math.Round(200.0f / cardsLeftInDeck, 1) + "%";
+            var drawNextTurn2 = Math.Round(200.0f / cardsLeftInDeck, 1);
+            LblDrawChance2.Text = (cardsLeftInDeck == 1 ? 100 : drawNextTurn2) + "%";
             LblDrawChance1.Text = Math.Round(100.0f / cardsLeftInDeck, 1) + "%";
         }
 


### PR DESCRIPTION
A fix for the board attack when cards are in the wrong zones. Sometimes graveyard, hand and deck. Also, removed the exclusion of Icehowl don't think it was correct in the first place.

Fixed the draw chances 200% thing while I was at it.