### PR TITLE
Fixed issue #1798

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,63 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+###############################################################################
+# Set default behavior for command prompt diff.
+#
+# This is need for earlier builds of msysgit that does not have it on by
+# default for csharp files.
+# Note: This is only used by command line
+###############################################################################
+#*.cs     diff=csharp
+
+###############################################################################
+# Set the merge driver for project and solution files
+#
+# Merging from the command prompt will add diff markers to the files if there
+# are conflicts (Merging from VS is not affected by the settings below, in VS
+# the diff markers are never inserted). Diff markers may cause the following 
+# file extensions to fail to load in VS. An alternative would be to treat
+# these files as binary and thus will always conflict and require user
+# intervention with every merge. To do so, just uncomment the entries below
+###############################################################################
+#*.sln       merge=binary
+#*.csproj    merge=binary
+#*.vbproj    merge=binary
+#*.vcxproj   merge=binary
+#*.vcproj    merge=binary
+#*.dbproj    merge=binary
+#*.fsproj    merge=binary
+#*.lsproj    merge=binary
+#*.wixproj   merge=binary
+#*.modelproj merge=binary
+#*.sqlproj   merge=binary
+#*.wwaproj   merge=binary
+
+###############################################################################
+# behavior for image files
+#
+# image files are treated as binary by default.
+###############################################################################
+#*.jpg   binary
+#*.png   binary
+#*.gif   binary
+
+###############################################################################
+# diff behavior for common document formats
+# 
+# Convert binary document formats to text before diffing them. This feature
+# is only available from the command line. Turn it on by uncommenting the 
+# entries below.
+###############################################################################
+#*.doc   diff=astextplain
+#*.DOC   diff=astextplain
+#*.docx  diff=astextplain
+#*.DOCX  diff=astextplain
+#*.dot   diff=astextplain
+#*.DOT   diff=astextplain
+#*.pdf   diff=astextplain
+#*.PDF   diff=astextplain
+#*.rtf   diff=astextplain
+#*.RTF   diff=astextplain

--- a/Hearthstone Deck Tracker/Enums/HeroClass.cs
+++ b/Hearthstone Deck Tracker/Enums/HeroClass.cs
@@ -2,6 +2,7 @@
 {
 	public enum HeroClass
 	{
+        None,
 		Druid,
 		Hunter,
 		Mage,

--- a/Hearthstone Deck Tracker/Windows/AddGameDialog.xaml
+++ b/Hearthstone Deck Tracker/Windows/AddGameDialog.xaml
@@ -20,6 +20,7 @@
         <DockPanel Margin="0,2,0,0">
             <Label Content="VS:" Width="90"/>
             <ComboBox Name="ComboBoxOpponent" SelectedIndex="0">
+                <enums:HeroClass>None</enums:HeroClass>
                 <enums:HeroClass>Druid</enums:HeroClass>
                 <enums:HeroClass>Hunter</enums:HeroClass>
                 <enums:HeroClass>Mage</enums:HeroClass>

--- a/Hearthstone Deck Tracker/Windows/AddGameDialog.xaml.cs
+++ b/Hearthstone Deck Tracker/Windows/AddGameDialog.xaml.cs
@@ -64,7 +64,9 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls
 			if(game == null)
 				return;
 			ComboBoxResult.SelectedItem = game.Result;
-			ComboBoxOpponent.SelectedItem = (HeroClass)Enum.Parse(typeof(HeroClass), game.OpponentHero);
+            HeroClass opponentHero;
+            Enum.TryParse<HeroClass>(game.OpponentHero, out opponentHero);
+			ComboBoxOpponent.SelectedItem = opponentHero;
 			ComboBoxMode.SelectedItem = game.GameMode;
 			ComboBoxRegion.SelectedItem = game.Region;
 			if(game.GameMode == GameMode.Ranked)


### PR DESCRIPTION
I fixed the issue #1798 where the client would crash when the HeroClass was left as a null value in the AddGameDialog and so when it tried to parse that to the HeroClass enum it just crashed the client. When I played against an opponent who disconnected it never saved the HeroClass value in DeckStats.xml which turned it into a null value. As a solution to this I added a default "None" value for the enum HeroClass and changed the Parse to a TryParse to fetch any null values and turn them into None's.