### PR TITLE
Use default font for non-latin languages

### DIFF
--- a/Hearthstone Deck Tracker/Controls/Card.xaml
+++ b/Hearthstone Deck Tracker/Controls/Card.xaml
@@ -18,7 +18,7 @@
                                  TextAlignment="Center" FontSize="20" Grid.Column="0" />
         <local:OutlinedTextBlock Height="16" VerticalAlignment="Center" Text="{Binding LocalizedName}"
                                  Fill="{Binding ColorPlayer}"
-                                 FontFamily="/HearthstoneDeckTracker;component/Resources/#Belwe Bd BT"
+                                 FontFamily="{Binding Font}"
                                  TextAlignment="Left" FontSize="13" Grid.Column="1" />
     </Grid>
 </UserControl>

--- a/Hearthstone Deck Tracker/Controls/CardToolTipControl.xaml
+++ b/Hearthstone Deck Tracker/Controls/CardToolTipControl.xaml
@@ -28,7 +28,7 @@
                                             Visibility="{Binding ShowIconsInTooltip}" />
                 <hearthstoneDeckTracker:HearthstoneTextBlock Text="{Binding LocalizedName}" Grid.Column="1" FontSize="14"
                                             VerticalAlignment="Center" HorizontalAlignment="Center" TextWrapping="Wrap"
-                                            TextAlignment="Center" />
+                                            TextAlignment="Center" FontFamily="{Binding Font}" />
                 <Image Source="../Resources/health.png" Width="35" Height="35" Grid.Column="2"
                        VerticalAlignment="Center" HorizontalAlignment="Center"
                        Visibility="{Binding ShowIconsInTooltip}" />

--- a/Hearthstone Deck Tracker/Controls/DeckListView.xaml
+++ b/Hearthstone Deck Tracker/Controls/DeckListView.xaml
@@ -24,7 +24,7 @@
                     <DataTemplate>
                         <local:OutlinedTextBlock Fill="{Binding ColorPlayer}" Margin="-2,0,0,0" Height="16"
                                                  VerticalAlignment="Center" Text="{Binding LocalizedName}"
-                                                 FontFamily="/HearthstoneDeckTracker;component/Resources/#Belwe Bd BT"
+                                                 FontFamily="{Binding Font}"
                                                  TextAlignment="Left" FontSize="13" />
                     </DataTemplate>
                 </GridViewColumn.CellTemplate>

--- a/Hearthstone Deck Tracker/Hearthstone/Card.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Card.cs
@@ -412,6 +412,21 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			}
 		}
 
+		public FontFamily Font
+		{
+			get
+			{
+				var lang = Config.Instance.SelectedLanguage;
+				var font = new FontFamily();
+				// if the language uses a Latin script use Belwe font
+				if(Helper.LatinLanguages.Contains(lang))
+				{
+					font = new FontFamily(new Uri("pack://application:,,,/"), "./resources/#Belwe Bd BT");
+				}
+				return font;
+			}
+		}
+
 		public ImageBrush Background
 		{
 			get

--- a/Hearthstone Deck Tracker/Hearthstone/Entities/Entity.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Entities/Entity.cs
@@ -177,6 +177,22 @@ namespace Hearthstone_Deck_Tracker.Hearthstone.Entities
 		}
 
 		[JsonIgnore]
+		public FontFamily Font
+		{
+			get
+			{
+				var lang = Config.Instance.SelectedLanguage;
+				var font = new FontFamily();
+				// if the language uses a Latin script use Belwe font
+				if(Helper.LatinLanguages.Contains(lang))
+				{
+					font = new FontFamily(new Uri("pack://application:,,,/"), "./resources/#Belwe Bd BT");
+				}
+				return font;
+			}
+		}
+
+		[JsonIgnore]
 		public string LocalizedName
 		{
 			get { return Card.LocalizedName; }

--- a/Hearthstone Deck Tracker/Replay/Controls/BoardEntity.xaml
+++ b/Hearthstone Deck Tracker/Replay/Controls/BoardEntity.xaml
@@ -17,6 +17,7 @@
         <DockPanel Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}">
             <Grid DockPanel.Dock="Top" Background="{DynamicResource AccentColorBrush}">
                 <local:HearthstoneTextBlock Text="{Binding LocalizedName}" FontSize="14"
+                                            FontFamily="{Binding Font}"
                                             VerticalAlignment="Center" HorizontalAlignment="Center" TextWrapping="Wrap"
                                             TextAlignment="Center" Height="20"/>
             </Grid>

--- a/Hearthstone Deck Tracker/Replay/Controls/CardEntity.xaml
+++ b/Hearthstone Deck Tracker/Replay/Controls/CardEntity.xaml
@@ -22,8 +22,7 @@
                                  FontFamily="/HearthstoneDeckTracker;component/Resources/#Belwe Bd BT"
                                  TextAlignment="Center" FontSize="20" Grid.Column="0" />
         <local:OutlinedTextBlock Height="16" VerticalAlignment="Center" Text="{Binding LocalizedName}"
-                                 
-                                 FontFamily="/HearthstoneDeckTracker;component/Resources/#Belwe Bd BT"
+                                 FontFamily="{Binding Font}"
                                  TextAlignment="Left" FontSize="13" Grid.Column="1" />
     </Grid>
 </UserControl>

--- a/Hearthstone Deck Tracker/Utility/Helper.cs
+++ b/Hearthstone Deck Tracker/Utility/Helper.cs
@@ -62,6 +62,11 @@ namespace Hearthstone_Deck_Tracker
 			{"Spanish (Mexico)", "esMX"},
 			{"Spanish (Spain)", "esES"}
 		};
+		public static readonly List<string> LatinLanguages = new List<string>
+		{
+			"enUS", "enGB", "frFR", "deDE", "itIT", "ptBR", "esMX", "esES"
+		};
+
 
         [Obsolete("Use Core.MainWindow")]
 		public static MainWindow MainWindow { get { return Core.MainWindow; } }


### PR DESCRIPTION
Tested out problem with the Russian language (#1794, #1783, #1756, #1753, #1623), the OS solutions didn't seem to work for me either.
So, added a new **Font** binding prop on `Card` and `Entity` that only uses *Belwe* if the selected lang  is a *Latin* type language, otherwise it should use the default system font.

There's probably a nicer way, but it works :smile: 