### PR TITLE
Fix deck version switch on canceling deck editing

### DIFF
--- a/Hearthstone Deck Tracker/Controls/DeckPicker/DeckPicker.xaml.cs
+++ b/Hearthstone Deck Tracker/Controls/DeckPicker/DeckPicker.xaml.cs
@@ -520,6 +520,12 @@ namespace Hearthstone_Deck_Tracker.Controls.DeckPicker
 							SelectClass(heroClass);
 					}
 
+					DeckType deckType = (DeckType) this.ListViewDeckType.SelectedIndex;
+					if (deckType != DeckType.All && deck.IsArenaDeck != (deckType == DeckType.Arena))
+					{
+						SelectDeckType(DeckType.All);
+					}
+
 					UpdateDecks();
 					dpi = _displayedDecks.FirstOrDefault(x => Equals(x.Deck, deck));
 					if(dpi == null)


### PR DESCRIPTION
Canceling editing a deck doesn't change selected version of this deck
anymore.

Fixes: #1822