### PR TITLE
Fix importing non-collectible cards

### DIFF
--- a/HDTTests/BoardDamage/PlayerBoardTest.cs
+++ b/HDTTests/BoardDamage/PlayerBoardTest.cs
@@ -9,7 +9,6 @@ namespace HDTTests.BoardDamage
 	public class PlayerBoardTest
 	{
 		private List<CardEntity> _cards;
-		private List<CardEntity> _exceptions;
 
 		[TestInitialize]
 		public void Setup()

--- a/HDTTests/Hearthstone/CardDbTest.cs
+++ b/HDTTests/Hearthstone/CardDbTest.cs
@@ -45,6 +45,20 @@ namespace HDTTests.Hearthstone
 		}
 
 		[TestMethod]
+		public void GetFromName_CollectibleByDefault()
+		{
+			var card = Database.GetCardFromName("Baron Geddon");
+			Assert.AreEqual("EX1_249", card.Id);
+		}
+
+		[TestMethod]
+		public void GetFromName_AllWithParam()
+		{
+			var card = Database.GetCardFromName("Baron Geddon", collectible: false);
+			Assert.IsTrue(card.Id.Contains("BRMA05"));
+		}
+
+		[TestMethod]
 		public void TestHeroSkins()
 		{
 			var Alleria = Database.GetHeroNameFromId("HERO_05a");

--- a/HDTTests/Hearthstone/WebImportTest.cs
+++ b/HDTTests/Hearthstone/WebImportTest.cs
@@ -32,7 +32,7 @@ namespace HDTTests.Hearthstone
 		public void Hearthpwn()
 		{
 			Deck expected = CreateDeck();
-			Deck found = DeckImporter.Import(@"http://www.hearthpwn.com/decks/274631-senfglas-1-legend-grim-patron-warrior-1074").Result;
+			Deck found = DeckImporter.Import(@"http://www.hearthpwn.com/decks/267064-grim-patron-senfglas").Result;
 			Assert.IsTrue(AreDecksEqual(expected, found));
 		}
 

--- a/Hearthstone Deck Tracker/Hearthstone/Database.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Database.cs
@@ -25,12 +25,12 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 			return new Card(cardId, null, Rarity.Free, "Minion", "UNKNOWN", 0, "UNKNOWN", 0, 1, "", "", 0, 0, "UNKNOWN", null, 0, "", "");
 		}
 
-		public static Card GetCardFromName(string name, bool localized = false, bool showErrorMessage = true)
+		public static Card GetCardFromName(string name, bool localized = false, bool showErrorMessage = true, bool collectible = true)
 		{
 			Language lang = Language.enUS;
 			if(localized)
 				Enum.TryParse(Config.Instance.SelectedLanguage, out lang);
-			var card = Cards.GetFromName(name, lang, false);
+			var card = Cards.GetFromName(name, lang, collectible);
 			if(card != null)
 				return new Card(card);
 			if(showErrorMessage)


### PR DESCRIPTION
*Baron Geddon* is being imported as the hero, instead of the card (#1883, #1907). Made `Database.GetCardFromName` be collectible by default, with the option of using a named param to make non-collectible if needed (I don't see anywhere that it is though).

*Also, quick fix for Hearthpwn import test - changed the url.*