### PR TITLE
Issue #1921 - Close with Hearthstone does not work.

### DIFF
--- a/Hearthstone Deck Tracker/Utility/User32.cs
+++ b/Hearthstone Deck Tracker/Utility/User32.cs
@@ -109,15 +109,14 @@ namespace Hearthstone_Deck_Tracker
 					GetClassName(process.MainWindowHandle, sb, 200);
 					if(sb.ToString().Equals("UnityWndClass", StringComparison.InvariantCultureIgnoreCase))
 					{
-                        
-                        _hsWindow = process.MainWindowHandle;
-                        _lastCheck = DateTime.Now;
-                        return _hsWindow;
+						_hsWindow = process.MainWindowHandle;
+						_lastCheck = DateTime.Now;
+						return _hsWindow;
 					}
 				}
 
-                _lastCheck = DateTime.Now;
-                return IntPtr.Zero;
+			_lastCheck = DateTime.Now;
+			return IntPtr.Zero;
 			}
 			else
 			{

--- a/Hearthstone Deck Tracker/Utility/User32.cs
+++ b/Hearthstone Deck Tracker/Utility/User32.cs
@@ -109,10 +109,15 @@ namespace Hearthstone_Deck_Tracker
 					GetClassName(process.MainWindowHandle, sb, 200);
 					if(sb.ToString().Equals("UnityWndClass", StringComparison.InvariantCultureIgnoreCase))
 					{
-						_hsWindow = process.MainWindowHandle;
-						break;
+                        
+                        _hsWindow = process.MainWindowHandle;
+                        _lastCheck = DateTime.Now;
+                        return _hsWindow;
 					}
 				}
+
+                _lastCheck = DateTime.Now;
+                return IntPtr.Zero;
 			}
 			else
 			{


### PR DESCRIPTION
The code segment that HDT enters when "Use Advanced Search" is selected never actually returned IntPtr.Zero at any point (just ran through the processes and returned the old _hsWindow).

"Use Advanced Search" seems to be related to Issue #1857 in some form as well.