### PR TITLE
Improve the readme's help screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Features
 =========
 An in-game overlay:
 
-![Overlay](http://i.imgur.com/EWd6Ung.jpg "The overlay")
+![Overlay](http://i.imgur.com/6IyRti1.jpg "The overlay")
 
 The app: 
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Features
 =========
 An in-game overlay:
 
-![Overlay](http://i.imgur.com/6IyRti1.jpg "The overlay")
+![Overlay](http://i.imgur.com/3ZX9Elm.jpg "The overlay")
 
 The app: 
 


### PR DESCRIPTION
The current readme's help screenshot shows an old version of the app that didn't have the fancy UI elements yet. I did a new screenshot from the newest version and added some help popups on it, trying to mimick Hearthstone's look and feel. I tried to keep things simple, and didn't duplicate elements that have a similar icon (i.e. the player's drawing probabilities has the same icon as the opponent's).

![The new help screenshot](http://i.imgur.com/3ZX9Elm.jpg)