### PR TITLE
Added the option to automatically launch Hearthstone when HDT is launched

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -133,6 +133,9 @@ namespace Hearthstone_Deck_Tracker
 		[DefaultValue(false)]
 		public bool CloseWithHearthstone = false;
 
+		[DefaultValue(false)]
+		public bool StartHearthstoneWithHDT = false;
+
 		[DefaultValue(new string[0])]
 		public string[] ConstructedImportingIgnoreCachedIds = new string[0];
 

--- a/Hearthstone Deck Tracker/Core.cs
+++ b/Hearthstone Deck Tracker/Core.cs
@@ -125,6 +125,10 @@ namespace Hearthstone_Deck_Tracker
 			UpdateOverlayAsync();
 			NewsUpdater.UpdateAsync();
 			HotKeyManager.Load();
+
+			if(Helper.HearthstoneDirExists && Config.Instance.StartHearthstoneWithHDT && !Game.IsRunning)
+				Helper.StartHearthstoneAsync();
+
 			Initialized = true;
 
 			Analytics.Analytics.TrackPageView($"/app/v{Helper.GetCurrentVersion().ToVersionString()}/{loginType.ToString().ToLower()}{(newUser ? "/new" : "")}", "");

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerSettings.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerSettings.xaml
@@ -76,6 +76,11 @@
                               Margin="10,5,0,0" VerticalAlignment="Top"
                               Checked="CheckboxCloseWithHearthstone_Checked"
                               Unchecked="CheckboxCloseWithHearthstone_Unchecked" />
+                    <CheckBox x:Name="CheckboxStartHearthstoneWithHDT"
+                              Content="Start Hearthstone with HDT" HorizontalAlignment="Left"
+                              Margin="10,5,0,0" VerticalAlignment="Top"
+                              Checked="CheckboxStartHearthstoneWithHDT_Checked"
+                              Unchecked="CheckboxStartHearthstoneWithHDT_Unchecked" />
                     <CheckBox x:Name="CheckboxCheckForUpdates" Content="Check for updates"
                               Foreground="{Binding Color, Source={x:Static options:AdvancedOptions.Instance}}"
                               Visibility="{Binding Visibility, Source={x:Static options:AdvancedOptions.Instance}}"

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerSettings.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerSettings.xaml.cs
@@ -38,6 +38,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			CheckboxCheckForUpdates.IsChecked = Config.Instance.CheckForUpdates;
 			CheckboxCheckForBetaUpdates.IsChecked = Config.Instance.CheckForBetaUpdates;
 			CheckboxCloseWithHearthstone.IsChecked = Config.Instance.CloseWithHearthstone;
+			CheckboxStartHearthstoneWithHDT.IsChecked = Config.Instance.StartHearthstoneWithHDT;
 			CheckboxConfigSaveAppData.IsChecked = Config.Instance.SaveConfigInAppData;
 			CheckboxDataSaveAppData.IsChecked = Config.Instance.SaveDataInAppData;
 			CheckboxAdvancedWindowSearch.IsChecked = Config.Instance.UseAnyUnityWindow;
@@ -149,6 +150,22 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			if(!_initialized)
 				return;
 			Config.Instance.CloseWithHearthstone = false;
+			Config.Save();
+		}
+		
+		private void CheckboxStartHearthstoneWithHDT_Checked(object sender, RoutedEventArgs e)
+		{
+			if (!_initialized)
+				return;
+			Config.Instance.StartHearthstoneWithHDT = true;
+			Config.Save();
+		}
+
+		private void CheckboxStartHearthstoneWithHDT_Unchecked(object sender, RoutedEventArgs e)
+		{
+			if (!_initialized)
+				return;
+			Config.Instance.StartHearthstoneWithHDT = false;
 			Config.Save();
 		}
 


### PR DESCRIPTION
This option goes together well with "Start minimized" and "Close with Hearthstone" for a more automated experience. Uses the existing functionality in Hearthstone_Deck_Tracker.Helper.StartHearthstoneAsync(). Disabled by default.