### PR TITLE
fix the wrong reference location of  HearthDb.dll in HDTTests project

### DIFF
--- a/HDTTests/HDTTests.csproj
+++ b/HDTTests/HDTTests.csproj
@@ -36,9 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="HearthDb, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Visual Studio 2015\Projects\HearthDb\HearthDb\bin\Release\HearthDb.dll</HintPath>
+    <Reference Include="HearthDb">
+      <HintPath>..\lib\HearthDb.dll</HintPath>
     </Reference>
     <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
       <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>


### PR DESCRIPTION
From 
..\..\..\..\Visual Studio 2015\Projects\HearthDb\HearthDb\bin\Release\HearthDb.dll
To
..\lib\HearthDb.dll